### PR TITLE
Add recurring transaction forecasts

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,159 @@
+# Tallyo repository context
+
+This is a personal-finance inspection application. A single user imports or
+creates transactions, maps transaction descriptions to merchants and categories,
+reviews them, and explores spending/income through reports and dashboard charts.
+
+## Repository map
+
+```
+apps/web       React single-page application
+apps/server    Hono API, oRPC procedures, PostgreSQL/Drizzle data layer
+compose.yml    Local PostgreSQL and production-style server container
+ops/           Operational backup-related material
+```
+
+The repository is an npm-workspaces Turborepo. Node/npm are used throughout;
+the declared package manager is npm 10.8.2. Biome is the formatter/linter.
+
+## Technology and request flow
+
+```
+React 19 + Vite + TanStack Router/Query
+  -> browser oRPC client (/rpc, cookie credentials)
+  -> Hono + oRPC handlers
+  -> Drizzle ORM
+  -> PostgreSQL 16
+```
+
+The web app imports the server router type directly, so changing an oRPC
+contract usually affects both applications at compile time.
+
+`apps/server/src/index.ts` is the server composition root. It exposes:
+
+- `/api/auth/*` — custom authentication endpoints;
+- `/api/*` — bearer-token external REST API (including transaction import);
+- `/rpc/*` — authenticated internal oRPC API used by the web app;
+- `/` — health check in development, or the built SPA in production.
+
+In development the web app runs at `http://localhost:3001` and the API at
+`http://localhost:3000`. The web oRPC client deliberately uses the current
+origin (`/rpc`), making the Vite proxy configuration relevant for local work.
+
+## Domain model and invariants
+
+The primary schema is in `apps/server/src/db/schema/app.ts` (auth tables are
+separate in `schema/auth.ts`). All main records are scoped by `userId`.
+
+- `settings`: one row per user; developer mode, privacy mode, and webhook URLs.
+- `categories`: optionally hierarchical via `parentCategoryId`; categories can
+  be income categories or excluded from insights.
+- `merchants`: normalized vendors with an optional recommended category.
+- `merchant_keywords`: user-owned keyword-to-merchant matching rules.
+- `transactions`: amount, date, details, notes, relations, review status, and
+  optional `splitFromId`; `(externalId, userId)` is unique for idempotent
+  imports.
+- `auth_token`: one generated bearer token per user for the external API.
+
+Amounts are integer cents. Positive values represent income and negative values
+represent expenses. UI forms convert dollars to cents before calling the API.
+
+Merchant keyword matching and category recommendation are handled in
+`apps/server/src/routers/merchants.ts` and shared matching helpers. Transaction
+creation/import should preserve those rules. A split transaction's child amounts
+must exactly sum to its original transaction amount.
+
+## Application surfaces
+
+File-based page routes live in `apps/web/src/routes/`:
+
+- `/` landing page; signed-in users are redirected to `/dashboard`.
+- `/dashboard` charts, period insights, merchant/category/transaction stats,
+  and Sankey visualization.
+- `/transactions` table, search/filtering, manual creation, reporting, review,
+  notes, and splitting.
+- `/categories` and `/merchants` manage the normalization taxonomy.
+- `/reports`, `/settings`, `/privacy`, and `/terms` complete the main UI.
+- `/_auth/signin` contains the sign-in route.
+
+Reusable product components are grouped by feature under
+`apps/web/src/components/`; generic shadcn-style primitives are under `ui/`.
+The root route owns auth-aware layout, theme selection, toasts, keyboard
+shortcuts, and development tools.
+
+## Server contracts
+
+`apps/server/src/routers/index.ts` combines the internal oRPC API:
+
+- `auth`: user existence, session, sign-out, Discord OAuth URL.
+- `categories`: list/create/update/delete.
+- `merchants`: list/create/update/delete, apply matching, bulk application, and
+  merging.
+- `transactions`: create/list/update category or merchant/toggle review/update
+  notes/delete/split/report.
+- `dashboard`: aggregate category, merchant, transaction, Sankey, and count
+  data.
+- `settings`: user preferences and external API token lifecycle.
+- `meta`: webhook refresh and account metadata.
+
+The external REST API is implemented in `apps/server/src/external-api.ts`; its
+human-facing reference is `apps/server/src/external-api-docs.md`. It authenticates
+with `Authorization: Bearer <token>` and supports bulk transaction insertion,
+listing, and related resource operations. Imports are limited to 100
+transactions per request and ignore duplicate external IDs.
+
+## Authentication and configuration
+
+Authentication is custom Discord OAuth/session code, despite older
+`BETTER_AUTH_*` variable names and README wording. The server validates these at
+module load:
+
+- `DISCORD_CLIENT_ID`
+- `DISCORD_CLIENT_SECRET`
+- `CORS_ORIGIN`
+
+`DISCORD_REDIRECT_URI` is optional and otherwise derives from `CORS_ORIGIN`.
+`DATABASE_URL` is needed by Drizzle. `apps/server/.env.example` includes the
+database/CORS defaults but currently omits the two required Discord variables;
+add them to a real local `.env` before starting the server.
+
+Sessions last 30 days and are stored in PostgreSQL. The app's current model is
+effectively single-user: after the first registration, only the originally
+linked Discord account can sign in.
+
+## Development workflow
+
+```bash
+npm install
+npm run db:dev                 # starts local PostgreSQL (port 5432)
+cp apps/server/.env.example apps/server/.env
+# add Discord credentials to apps/server/.env
+npm run db:push                # apply schema to the database
+npm run dev                    # web :3001 and server :3000
+```
+
+Useful commands:
+
+- `npm run check-types` — TypeScript checks across the apps.
+- `npm run check` — Biome check with `--write` (it can modify files).
+- `npm run build` — builds both web and server.
+- `npm run db:generate` / `npm run db:migrate` — create/apply Drizzle migrations.
+- `npm run db:seed` — seed starter data for the first user.
+- `npm run db:down` — stop the compose database.
+
+There is no dedicated automated test suite configured in the package scripts at
+the time this document was written. Use type checking and focused manual/API
+verification when changing behavior.
+
+## Change guide
+
+- Start API work in the relevant router, then follow the inferred type into the
+  corresponding web component or route.
+- Keep user ownership checks and transaction amount-in-cents semantics intact.
+- Make schema changes in `db/schema/`, then generate a migration and update the
+  data-access code; do not edit existing migrations retroactively.
+- For production bundling, the server `build:full` script builds the web app and
+  copies its assets to `apps/server/public`; the standard root build builds both
+  workspaces but does not perform that copy.
+- Preserve unrelated uncommitted changes. This repository may include local
+  database data in `postgres-data/`; treat it as environment state, not source.

--- a/apps/server/src/db/migrations/0003_add_recurring_transactions.sql
+++ b/apps/server/src/db/migrations/0003_add_recurring_transactions.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "recurring_transactions" (
+  "id" text PRIMARY KEY NOT NULL,
+  "user_id" text NOT NULL,
+  "source_transaction_id" text NOT NULL,
+  "merchant_id" text,
+  "category_id" text,
+  "amount" integer NOT NULL,
+  "transaction_details" text NOT NULL,
+  "start_date" date NOT NULL,
+  "day_of_month" integer NOT NULL,
+  "active" boolean DEFAULT true NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "recurring_transactions_source_transaction_unique" ON "recurring_transactions" USING btree ("source_transaction_id");

--- a/apps/server/src/db/migrations/meta/0003_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,837 @@
+{
+  "id": "fb4256e3-cbe6-4626-94ab-823a1b11b4af",
+  "prevId": "fc469d94-7a31-456e-ab2e-3a5a056e0e40",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_token": {
+      "name": "auth_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_token_user_id_unique": {
+          "name": "auth_token_user_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_token_token_unique": {
+          "name": "auth_token_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_category_id": {
+          "name": "parent_category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "treat_as_income": {
+          "name": "treat_as_income",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_from_insights": {
+          "name": "hide_from_insights",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "category_name_user_id_unique": {
+          "name": "category_name_user_id_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.merchants": {
+      "name": "merchants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_category_id": {
+          "name": "recommended_category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "merchant_name_user_id_unique": {
+          "name": "merchant_name_user_id_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.merchant_keywords": {
+      "name": "merchant_keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "merchant_keyword_unique": {
+          "name": "merchant_keyword_unique",
+          "columns": [
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_transactions": {
+      "name": "recurring_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_transaction_id": {
+          "name": "source_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_details": {
+          "name": "transaction_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurring_transactions_source_transaction_unique": {
+          "name": "recurring_transactions_source_transaction_unique",
+          "columns": [
+            {
+              "expression": "source_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_dev_mode": {
+          "name": "is_dev_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_privacy_mode": {
+          "name": "is_privacy_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "webhook_urls": {
+          "name": "webhook_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_user_id_unique": {
+          "name": "settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_details": {
+          "name": "transaction_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "split_from_id": {
+          "name": "split_from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transaction_external_id_user_id_unique": {
+          "name": "transaction_external_id_user_id_unique",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1762822232526,
       "tag": "0002_chubby_meggan",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1785020033967,
+      "tag": "0003_add_recurring_transactions",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema/app.ts
+++ b/apps/server/src/db/schema/app.ts
@@ -171,6 +171,32 @@ export const transactionRelations = relations(transaction, ({ one }) => ({
   }),
 }));
 
+// A recurring rule is a projection source, not a posted transaction.
+export const recurringTransaction = pgTable(
+  "recurring_transactions",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn((): string => crypto.randomUUID()),
+    userId: text("user_id").notNull(),
+    sourceTransactionId: text("source_transaction_id").notNull(),
+    merchantId: text("merchant_id"),
+    categoryId: text("category_id"),
+    amount: integer("amount").notNull(),
+    transactionDetails: text("transaction_details").notNull(),
+    startDate: date("start_date").notNull(),
+    dayOfMonth: integer("day_of_month").notNull(),
+    active: boolean("active").notNull().default(true),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("recurring_transactions_source_transaction_unique").on(
+      table.sourceTransactionId,
+    ),
+  ],
+);
+
 export const authToken = pgTable(
   "auth_token",
   {

--- a/apps/server/src/routers/dashboard.ts
+++ b/apps/server/src/routers/dashboard.ts
@@ -15,7 +15,13 @@ import {
 } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/db";
-import { category, merchant, merchantKeyword, transaction } from "@/db/schema";
+import {
+  category,
+  merchant,
+  merchantKeyword,
+  recurringTransaction,
+  transaction,
+} from "@/db/schema";
 import { protectedProcedure } from "../lib/orpc";
 
 const dateRangeSchema = z.object({
@@ -55,6 +61,65 @@ function _calculateVolatility(values: number[]): number {
 }
 
 type StatsDateRange = { from?: string; to?: string };
+
+function getMonthlyOccurrence(year: number, month: number, dayOfMonth: number) {
+  const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  return `${year}-${String(month).padStart(2, "0")}-${String(Math.min(dayOfMonth, lastDay)).padStart(2, "0")}`;
+}
+
+async function getForecastForDateRange(
+  userId: string,
+  dateRange: StatsDateRange,
+) {
+  if (!dateRange.from || !dateRange.to) {
+    return {
+      forecastedIncome: 0,
+      forecastedExpenses: 0,
+      forecastedTransactionCount: 0,
+    };
+  }
+
+  const rules = await db.query.recurringTransaction.findMany({
+    where: and(
+      eq(recurringTransaction.userId, userId),
+      eq(recurringTransaction.active, true),
+    ),
+  });
+  const [fromYear, fromMonth] = dateRange.from
+    .slice(0, 7)
+    .split("-")
+    .map(Number);
+  const [toYear, toMonth] = dateRange.to.slice(0, 7).split("-").map(Number);
+  let forecastedIncome = 0;
+  let forecastedExpenses = 0;
+  let forecastedTransactionCount = 0;
+
+  for (const rule of rules) {
+    for (
+      let year = fromYear, month = fromMonth;
+      year < toYear || (year === toYear && month <= toMonth);
+    ) {
+      const occurrence = getMonthlyOccurrence(year, month, rule.dayOfMonth);
+      // The source entry is already actual; forecast subsequent monthly occurrences.
+      if (
+        occurrence > rule.startDate &&
+        occurrence >= dateRange.from &&
+        occurrence <= dateRange.to
+      ) {
+        forecastedTransactionCount += 1;
+        if (rule.amount >= 0) forecastedIncome += rule.amount;
+        else forecastedExpenses += rule.amount;
+      }
+      month += 1;
+      if (month === 13) {
+        month = 1;
+        year += 1;
+      }
+    }
+  }
+
+  return { forecastedIncome, forecastedExpenses, forecastedTransactionCount };
+}
 
 /** Returns same-month day range (1–31) or null if range spans months or is invalid. */
 function getSameMonthDayWindow(
@@ -185,6 +250,9 @@ async function getStatsForDateRange(
     avgIncomeForWindow: number | null;
     avgExpenseForWindow: number | null;
     avgTransactionCountForWindow: number | null;
+    forecastedIncome: number;
+    forecastedExpenses: number;
+    forecastedTransactionCount: number;
   };
 }> {
   const [
@@ -473,6 +541,8 @@ async function getStatsForDateRange(
     }
   }
 
+  const forecastData = await getForecastForDateRange(userId, dateRange);
+
   return {
     stats: {
       totalTransactions:
@@ -511,6 +581,7 @@ async function getStatsForDateRange(
       avgIncomeForWindow,
       avgExpenseForWindow,
       avgTransactionCountForWindow,
+      ...forecastData,
     },
   };
 }

--- a/apps/server/src/routers/transactions.ts
+++ b/apps/server/src/routers/transactions.ts
@@ -11,7 +11,13 @@ import {
   sql,
 } from "drizzle-orm";
 import { z } from "zod";
-import { category, merchant, merchantKeyword, transaction } from "@/db/schema";
+import {
+  category,
+  merchant,
+  merchantKeyword,
+  recurringTransaction,
+  transaction,
+} from "@/db/schema";
 import { db } from "../db";
 import { logger } from "../lib/logger";
 import { protectedProcedure } from "../lib/orpc";
@@ -297,8 +303,39 @@ export const transactionsRouter = {
             offset: (input.page - 1) * input.pageSize,
           });
 
+          const recurringForecasts =
+            userTransactions.length > 0
+              ? await db
+                  .select({
+                    sourceTransactionId:
+                      recurringTransaction.sourceTransactionId,
+                  })
+                  .from(recurringTransaction)
+                  .where(
+                    and(
+                      eq(
+                        recurringTransaction.userId,
+                        context.session?.user?.id,
+                      ),
+                      eq(recurringTransaction.active, true),
+                      inArray(
+                        recurringTransaction.sourceTransactionId,
+                        userTransactions.map(
+                          (userTransaction) => userTransaction.id,
+                        ),
+                      ),
+                    ),
+                  )
+              : [];
+          const recurringSourceIds = new Set(
+            recurringForecasts.map((forecast) => forecast.sourceTransactionId),
+          );
+
           return {
-            transactions: userTransactions,
+            transactions: userTransactions.map((userTransaction) => ({
+              ...userTransaction,
+              hasRecurringForecast: recurringSourceIds.has(userTransaction.id),
+            })),
             pagination: {
               total: count,
               page: input.page,
@@ -428,21 +465,115 @@ export const transactionsRouter = {
       );
     }),
 
+  createRecurringForecast: protectedProcedure
+    .input(z.object({ transactionId: z.string() }))
+    .handler(async ({ input, context }) => {
+      return withErrorHandling(
+        async () => {
+          const source = await validateTransactionOwnership(
+            input.transactionId,
+            context.session?.user?.id,
+          );
+          const dayOfMonth = Number(source.date.slice(8, 10));
+
+          const [forecast] = await db
+            .insert(recurringTransaction)
+            .values({
+              userId: context.session?.user?.id,
+              sourceTransactionId: source.id,
+              merchantId: source.merchantId,
+              categoryId: source.categoryId,
+              amount: source.amount,
+              transactionDetails: source.transactionDetails,
+              startDate: source.date,
+              dayOfMonth,
+              active: true,
+            })
+            .onConflictDoUpdate({
+              target: recurringTransaction.sourceTransactionId,
+              set: {
+                merchantId: source.merchantId,
+                categoryId: source.categoryId,
+                amount: source.amount,
+                transactionDetails: source.transactionDetails,
+                startDate: source.date,
+                dayOfMonth,
+                active: true,
+                updatedAt: new Date(),
+              },
+            })
+            .returning();
+
+          return { forecast };
+        },
+        "Error creating recurring forecast",
+        context.session?.user?.id,
+      );
+    }),
+
+  removeRecurringForecast: protectedProcedure
+    .input(z.object({ transactionId: z.string() }))
+    .handler(async ({ input, context }) => {
+      return withErrorHandling(
+        async () => {
+          await validateTransactionOwnership(
+            input.transactionId,
+            context.session?.user?.id,
+          );
+          await db
+            .delete(recurringTransaction)
+            .where(
+              and(
+                eq(
+                  recurringTransaction.sourceTransactionId,
+                  input.transactionId,
+                ),
+                eq(recurringTransaction.userId, context.session?.user?.id),
+              ),
+            );
+          return { success: true };
+        },
+        "Error removing recurring forecast",
+        context.session?.user?.id,
+      );
+    }),
+
   deleteTransaction: protectedProcedure
     .input(z.object({ id: z.string() }))
-    .handler(async ({ input }) => {
-      return withErrorHandling(async () => {
-        const deletedTransaction = await db
-          .delete(transaction)
-          .where(eq(transaction.id, input.id))
-          .returning();
+    .handler(async ({ input, context }) => {
+      return withErrorHandling(
+        async () => {
+          await validateTransactionOwnership(
+            input.id,
+            context.session?.user?.id,
+          );
+          await db
+            .delete(recurringTransaction)
+            .where(
+              and(
+                eq(recurringTransaction.sourceTransactionId, input.id),
+                eq(recurringTransaction.userId, context.session?.user?.id),
+              ),
+            );
+          const deletedTransaction = await db
+            .delete(transaction)
+            .where(
+              and(
+                eq(transaction.id, input.id),
+                eq(transaction.userId, context.session?.user?.id),
+              ),
+            )
+            .returning();
 
-        if (!deletedTransaction || deletedTransaction.length === 0) {
-          throw new Error("Transaction not found");
-        }
+          if (!deletedTransaction || deletedTransaction.length === 0) {
+            throw new Error("Transaction not found");
+          }
 
-        return { success: true };
-      }, "Error deleting transaction");
+          return { success: true };
+        },
+        "Error deleting transaction",
+        context.session?.user?.id,
+      );
     }),
 
   splitTransaction: protectedProcedure
@@ -486,6 +617,14 @@ export const transactionsRouter = {
           }
 
           // Delete the original transaction
+          await db
+            .delete(recurringTransaction)
+            .where(
+              and(
+                eq(recurringTransaction.sourceTransactionId, input.id),
+                eq(recurringTransaction.userId, context.session?.user?.id),
+              ),
+            );
           await db.delete(transaction).where(eq(transaction.id, input.id));
 
           // Create new transactions for each split

--- a/apps/web/src/components/dashboard/category-pie-chart.tsx
+++ b/apps/web/src/components/dashboard/category-pie-chart.tsx
@@ -20,7 +20,7 @@ const chartColors = [
   "#f59e0b", // amber
   "#84cc16", // lime
   "#06b6d4", // cyan
-  "#8b5cf6", // violet
+  "#ea580c", // orange
 ];
 
 function hashString(str: string): number {

--- a/apps/web/src/components/dashboard/income-expense-sankey.tsx
+++ b/apps/web/src/components/dashboard/income-expense-sankey.tsx
@@ -29,7 +29,7 @@ const chartColors = [
   "#f59e0b",
   "#84cc16",
   "#06b6d4",
-  "#8b5cf6",
+  "#ea580c",
 ];
 
 function hashString(str: string): number {

--- a/apps/web/src/components/dashboard/stats.tsx
+++ b/apps/web/src/components/dashboard/stats.tsx
@@ -28,14 +28,28 @@ export function Stats({ data }: { data: DashboardStats | undefined }) {
 
   const income = Number(data.stats.totalIncome) || 0;
   const expenses = Number(data.stats.totalExpenses) || 0;
+  const forecastedIncome = Number(data.stats.forecastedIncome) || 0;
+  const forecastedExpenses = Number(data.stats.forecastedExpenses) || 0;
+  const hasForecasts = data.stats.forecastedTransactionCount > 0;
   const netIncome = income + expenses; // expenses are negative
-  const savingsRate = (() => {
-    const absIncome = Math.abs(income);
-    const absExpenses = Math.abs(expenses);
+  const calculateSavingsRate = (
+    incomeAmount: number,
+    expenseAmount: number,
+  ) => {
+    const absIncome = Math.abs(incomeAmount);
+    const absExpenses = Math.abs(expenseAmount);
     if (absIncome === 0) return 0;
     const rate = (absIncome - absExpenses) / absIncome;
     return Math.max(0, Math.round(rate * 100));
-  })();
+  };
+  const savingsRate = calculateSavingsRate(income, expenses);
+  const projectedIncome = income + forecastedIncome;
+  const projectedExpenses = expenses + forecastedExpenses;
+  const projectedNetIncome = projectedIncome + projectedExpenses;
+  const projectedSavingsRate = calculateSavingsRate(
+    projectedIncome,
+    projectedExpenses,
+  );
 
   return (
     <Card className="border-border/80 bg-card/90 p-4 sm:p-5">
@@ -58,6 +72,18 @@ export function Stats({ data }: { data: DashboardStats | undefined }) {
                 className="text-base font-semibold text-income tabular-nums"
               />
             </div>
+            {forecastedIncome > 0 && (
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-muted-foreground">
+                  Forecasted Income Remaining
+                </span>
+                <CurrencyAmount
+                  animate
+                  amount={forecastedIncome}
+                  className="text-sm font-semibold text-income tabular-nums"
+                />
+              </div>
+            )}
           </div>
         </div>
 
@@ -82,6 +108,36 @@ export function Stats({ data }: { data: DashboardStats | undefined }) {
                 />
               </div>
             </div>
+            {forecastedExpenses < 0 && (
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-muted-foreground">
+                  Forecasted Payments Remaining
+                </span>
+                <div className="flex items-center gap-1.5">
+                  <Minus className="h-3 w-3 text-muted-foreground" />
+                  <CurrencyAmount
+                    animate
+                    amount={Math.abs(forecastedExpenses)}
+                    className="text-sm font-semibold text-expense tabular-nums"
+                  />
+                </div>
+              </div>
+            )}
+            {forecastedExpenses < 0 && (
+              <div className="flex items-center justify-between pt-1">
+                <span className="text-sm font-medium text-foreground">
+                  Projected Total Expenses
+                </span>
+                <div className="flex items-center gap-1.5">
+                  <Minus className="h-3 w-3 text-muted-foreground" />
+                  <CurrencyAmount
+                    animate
+                    amount={Math.abs(projectedExpenses)}
+                    className="text-base font-semibold text-expense tabular-nums"
+                  />
+                </div>
+              </div>
+            )}
           </div>
         </div>
 
@@ -104,6 +160,26 @@ export function Stats({ data }: { data: DashboardStats | undefined }) {
               className="text-lg font-bold tabular-nums"
             />
           </div>
+          {hasForecasts && (
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                {projectedNetIncome >= 0 ? (
+                  <Plus className="h-4 w-4 text-income" />
+                ) : (
+                  <Minus className="h-4 w-4 text-expense" />
+                )}
+                <span className="text-sm font-medium text-foreground">
+                  Projected Net Income
+                </span>
+              </div>
+              <CurrencyAmount
+                animate
+                amount={projectedNetIncome}
+                showColor
+                className="text-lg font-bold tabular-nums"
+              />
+            </div>
+          )}
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <PiggyBankIcon className="h-4 w-4 text-savings" />
@@ -117,6 +193,21 @@ export function Stats({ data }: { data: DashboardStats | undefined }) {
               {savingsRate}%
             </span>
           </div>
+          {hasForecasts && (
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <PiggyBankIcon className="h-4 w-4 text-savings" />
+                <span className="text-sm text-muted-foreground">
+                  Projected Savings Rate
+                </span>
+              </div>
+              <span
+                className={`text-base font-semibold tabular-nums ${projectedSavingsRate >= 20 ? "text-savings" : projectedSavingsRate >= 10 ? "text-amber-500" : "text-muted-foreground"}`}
+              >
+                {projectedSavingsRate}%
+              </span>
+            </div>
+          )}
         </div>
       </div>
     </Card>

--- a/apps/web/src/components/transactions/split-transaction-dialog.tsx
+++ b/apps/web/src/components/transactions/split-transaction-dialog.tsx
@@ -85,6 +85,9 @@ export function SplitTransactionDialog({
     orpc.transactions.splitTransaction.mutationOptions({
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey });
+        queryClient.invalidateQueries({
+          queryKey: ["dashboard", "getStatsCounts"],
+        });
         onOpenChange(false);
         resetSplits();
       },

--- a/apps/web/src/components/transactions/transactions-table.tsx
+++ b/apps/web/src/components/transactions/transactions-table.tsx
@@ -930,7 +930,7 @@ export function TransactionsTable({
               <TableHead className="w-[72px] px-2 sm:px-3 text-center">
                 Reviewed
               </TableHead>
-              <TableHead className="w-[88px] px-2 sm:px-3 text-center">
+              <TableHead className="w-[120px] px-2 sm:px-3 text-center">
                 Actions
               </TableHead>
             </TableRow>

--- a/apps/web/src/components/transactions/transactions-table.tsx
+++ b/apps/web/src/components/transactions/transactions-table.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { format, parseISO } from "date-fns";
-import { Check, Split, Trash } from "lucide-react";
+import { Check, Repeat, Split, Trash } from "lucide-react";
 import {
   memo,
   type ReactNode,
@@ -64,6 +64,8 @@ interface TransactionsTableProps {
   updateNotes: (args: { id: string; notes: string }) => void;
   toggleReviewed: (args: { id: string }) => void;
   deleteTransaction: (args: { id: string }) => void;
+  createRecurringForecast: (args: { transactionId: string }) => void;
+  removeRecurringForecast: (args: { transactionId: string }) => void;
   onCategoryClick?: (categoryId: string) => void;
   onMerchantClick?: (merchantId: string) => void;
   isLoading?: boolean;
@@ -163,6 +165,8 @@ interface TransactionCardProps {
   onNoteBlur: (id: string, value: string) => void;
   onToggleReviewed: (id: string) => void;
   onDelete: (id: string) => void;
+  onCreateRecurringForecast: (transactionId: string) => void;
+  onRemoveRecurringForecast: (transactionId: string) => void;
   onCategoryChange: (id: string, categoryId: string | null) => void;
   onMerchantChange: (id: string, merchantId: string | null) => void;
   onEditMerchant: (merchantId: string) => void;
@@ -182,6 +186,8 @@ const TransactionCard = memo(function TransactionCard({
   onNoteBlur,
   onToggleReviewed,
   onDelete,
+  onCreateRecurringForecast,
+  onRemoveRecurringForecast,
   onCategoryChange,
   onMerchantChange,
   onEditMerchant,
@@ -261,6 +267,33 @@ const TransactionCard = memo(function TransactionCard({
           </div>
 
           <div className="flex items-center gap-1 shrink-0">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() =>
+                transaction.hasRecurringForecast
+                  ? onRemoveRecurringForecast(transaction.id)
+                  : onCreateRecurringForecast(transaction.id)
+              }
+              className={cn(
+                "h-10 w-10 hover:text-foreground",
+                transaction.hasRecurringForecast
+                  ? "text-income"
+                  : "text-muted-foreground",
+              )}
+              aria-label={
+                transaction.hasRecurringForecast
+                  ? "Stop forecasting monthly"
+                  : "Forecast monthly from this transaction"
+              }
+              title={
+                transaction.hasRecurringForecast
+                  ? "Stop forecasting monthly"
+                  : "Forecast monthly"
+              }
+            >
+              <Repeat className="h-5 w-5" />
+            </Button>
             {!isSplit && !transaction.reviewed && onSplit && (
               <Button
                 variant="ghost"
@@ -470,6 +503,8 @@ export function TransactionsTable({
   updateNotes,
   toggleReviewed,
   deleteTransaction,
+  createRecurringForecast,
+  removeRecurringForecast,
   onCategoryClick,
   onMerchantClick,
   isLoading = false,
@@ -571,6 +606,10 @@ export function TransactionsTable({
 
   const handleToggleReviewed = (id: string) => toggleReviewed({ id });
   const handleDelete = (id: string) => deleteTransaction({ id });
+  const handleCreateRecurringForecast = (transactionId: string) =>
+    createRecurringForecast({ transactionId });
+  const handleRemoveRecurringForecast = (transactionId: string) =>
+    removeRecurringForecast({ transactionId });
   const handleCategoryChange = (id: string, categoryId: string | null) =>
     updateCategory({ id, categoryId });
   const handleMerchantChange = (id: string, merchantId: string | null) =>
@@ -697,6 +736,54 @@ export function TransactionsTable({
           </TooltipTrigger>
           <TooltipContent>
             <p>Split transaction</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  };
+
+  const renderRecurringForecastButton = (
+    transaction: Transaction,
+    size: "sm" | "lg" = "sm",
+  ) => {
+    const buttonSizeClass = size === "lg" ? "h-10 w-10" : "h-8 w-8";
+    const iconSizeClass = size === "lg" ? "h-5 w-5" : "h-4 w-4";
+
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() =>
+                transaction.hasRecurringForecast
+                  ? handleRemoveRecurringForecast(transaction.id)
+                  : handleCreateRecurringForecast(transaction.id)
+              }
+              className={cn(
+                "hover:text-foreground hover:bg-muted/60 transition-colors",
+                buttonSizeClass,
+                transaction.hasRecurringForecast
+                  ? "text-income"
+                  : "text-muted-foreground",
+              )}
+              aria-label={
+                transaction.hasRecurringForecast
+                  ? "Stop forecasting monthly"
+                  : "Forecast monthly from this transaction"
+              }
+              disabled={isLoading}
+            >
+              <Repeat className={iconSizeClass} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>
+              {transaction.hasRecurringForecast
+                ? "Stop forecasting monthly"
+                : "Forecast monthly"}
+            </p>
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
@@ -1008,6 +1095,7 @@ export function TransactionsTable({
                   </TableCell>
                   <TableCell className="text-center px-2 sm:px-3 h-10 align-middle">
                     <div className="flex items-center justify-center gap-1">
+                      {renderRecurringForecastButton(transaction, "sm")}
                       {renderSplitButton(transaction, "sm")}
                       {renderDeleteButton(transaction, "sm")}
                     </div>
@@ -1050,6 +1138,8 @@ export function TransactionsTable({
               onNoteBlur={handleNoteBlur}
               onToggleReviewed={handleToggleReviewed}
               onDelete={handleDelete}
+              onCreateRecurringForecast={handleCreateRecurringForecast}
+              onRemoveRecurringForecast={handleRemoveRecurringForecast}
               onCategoryChange={handleCategoryChange}
               onMerchantChange={handleMerchantChange}
               onEditMerchant={(merchantId) =>

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -10,13 +10,13 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground border-transparent shadow-[0_1px_2px_rgba(124,58,237,0.15),0_2px_4px_rgba(124,58,237,0.1)] hover:shadow-[0_2px_4px_rgba(124,58,237,0.2),0_4px_8px_rgba(124,58,237,0.15)] hover:-translate-y-[1px]",
+          "bg-primary text-primary-foreground border-transparent shadow-[0_1px_2px_rgba(194,65,12,0.2),0_2px_4px_rgba(194,65,12,0.12)] hover:bg-primary/90 hover:shadow-[0_2px_4px_rgba(194,65,12,0.22),0_4px_8px_rgba(194,65,12,0.14)] hover:-translate-y-px",
         destructive:
           "bg-destructive text-destructive-foreground border-transparent shadow-[0_1px_2px_rgba(220,38,38,0.15),0_2px_4px_rgba(220,38,38,0.1)] hover:shadow-[0_2px_4px_rgba(220,38,38,0.2),0_4px_8px_rgba(220,38,38,0.15)] hover:-translate-y-[1px]",
         outline:
           "bg-transparent border-border text-foreground hover:bg-secondary hover:border-secondary-foreground/20 shadow-none",
         secondary:
-          "bg-secondary text-secondary-foreground border-transparent hover:bg-secondary/80 shadow-[0_1px_2px_rgba(68,55,43,0.05)]",
+          "bg-secondary text-secondary-foreground border-transparent hover:bg-secondary/80 shadow-[0_1px_2px_rgba(15,23,42,0.05)]",
         ghost:
           "bg-transparent text-foreground hover:bg-secondary/60 border-transparent shadow-none",
         link: "bg-transparent text-primary underline-offset-4 hover:underline border-transparent shadow-none",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -101,20 +101,20 @@
     "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif;
 
-  /* Warm, soft shadows */
+  /* Neutral, low-elevation shadows */
   --shadow-soft:
-    0 1px 2px rgba(68, 55, 43, 0.04), 0 4px 8px rgba(68, 55, 43, 0.03),
-    0 8px 16px rgba(68, 55, 43, 0.02);
+    0 1px 2px rgba(15, 23, 42, 0.04), 0 4px 8px rgba(15, 23, 42, 0.03),
+    0 8px 16px rgba(15, 23, 42, 0.02);
   --shadow-soft-lg:
-    0 2px 4px rgba(68, 55, 43, 0.04), 0 8px 16px rgba(68, 55, 43, 0.03),
-    0 16px 32px rgba(68, 55, 43, 0.02);
+    0 2px 4px rgba(15, 23, 42, 0.04), 0 8px 16px rgba(15, 23, 42, 0.03),
+    0 16px 32px rgba(15, 23, 42, 0.02);
   --shadow-soft-xl:
-    0 4px 8px rgba(68, 55, 43, 0.04), 0 12px 24px rgba(68, 55, 43, 0.03),
-    0 24px 48px rgba(68, 55, 43, 0.02);
+    0 4px 8px rgba(15, 23, 42, 0.04), 0 12px 24px rgba(15, 23, 42, 0.03),
+    0 24px 48px rgba(15, 23, 42, 0.02);
 
-  /* Glow effects */
-  --shadow-glow: 0 0 20px rgba(139, 92, 246, 0.2);
-  --shadow-glow-sm: 0 0 12px rgba(139, 92, 246, 0.12);
+  /* Accent glow effects */
+  --shadow-glow: 0 0 20px rgba(234, 88, 12, 0.18);
+  --shadow-glow-sm: 0 0 12px rgba(234, 88, 12, 0.1);
 }
 
 html,
@@ -129,69 +129,69 @@ body {
 }
 
 /* ==========================================
-   WARM & FRIENDLY THEME - Light Mode
+   TALLYO ORANGE - Light Mode
    ========================================== */
 
 :root {
-  /* Border radius - slightly more rounded for friendly feel */
-  --radius: 0.625rem;
-  --radius-sm: 0.375rem;
-  --radius-md: 0.625rem;
-  --radius-lg: 0.875rem;
-  --radius-xl: 1.125rem;
+  /* A compact, consistent radius scale */
+  --radius: 0.75rem;
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.25rem;
   --radius-2xl: 1.5rem;
 
   /* Shadows */
   --shadow-soft:
-    0 1px 2px rgba(68, 55, 43, 0.04), 0 4px 8px rgba(68, 55, 43, 0.03),
-    0 8px 16px rgba(68, 55, 43, 0.02);
+    0 1px 2px rgba(15, 23, 42, 0.04), 0 4px 8px rgba(15, 23, 42, 0.03),
+    0 8px 16px rgba(15, 23, 42, 0.02);
   --shadow-soft-lg:
-    0 2px 4px rgba(68, 55, 43, 0.04), 0 8px 16px rgba(68, 55, 43, 0.03),
-    0 16px 32px rgba(68, 55, 43, 0.02);
+    0 2px 4px rgba(15, 23, 42, 0.04), 0 8px 16px rgba(15, 23, 42, 0.03),
+    0 16px 32px rgba(15, 23, 42, 0.02);
   --shadow-soft-xl:
-    0 4px 8px rgba(68, 55, 43, 0.04), 0 12px 24px rgba(68, 55, 43, 0.03),
-    0 24px 48px rgba(68, 55, 43, 0.02);
-  --shadow-glow: 0 0 20px rgba(139, 92, 246, 0.15);
-  --shadow-glow-sm: 0 0 12px rgba(139, 92, 246, 0.1);
+    0 4px 8px rgba(15, 23, 42, 0.04), 0 12px 24px rgba(15, 23, 42, 0.03),
+    0 24px 48px rgba(15, 23, 42, 0.02);
+  --shadow-glow: 0 0 20px rgba(234, 88, 12, 0.15);
+  --shadow-glow-sm: 0 0 12px rgba(234, 88, 12, 0.1);
 
   /* ==========================================
      BASE COLORS - Warm Neutrals
      ========================================== */
 
-  /* Background - warm off-white with subtle cream */
-  --background: #faf9f7;
-  --foreground: #1c1917;
+  /* Neutral surfaces keep attention on content and actions */
+  --background: #fafafa;
+  --foreground: #171717;
 
-  /* Card - pure white with subtle warmth */
+  /* Card - clean surface against a neutral canvas */
   --card: #ffffff;
-  --card-foreground: #1c1917;
+  --card-foreground: #171717;
 
   /* Popover - white with soft shadow potential */
   --popover: #ffffff;
-  --popover-foreground: #1c1917;
+  --popover-foreground: #171717;
 
   /* ==========================================
-     PRIMARY - Vibrant Violet
+     PRIMARY - Burnt Orange
      ========================================== */
-  --primary: #7c3aed;
+  --primary: #c2410c;
   --primary-foreground: #ffffff;
 
   /* ==========================================
-     SECONDARY - Soft Purple Tint
+     SECONDARY - Cool Gray
      ========================================== */
-  --secondary: #f5f3ff;
-  --secondary-foreground: #5b21b6;
+  --secondary: #f1f5f9;
+  --secondary-foreground: #334155;
 
   /* ==========================================
      MUTED - Soft Warm Gray
      ========================================== */
-  --muted: #faf9f7;
-  --muted-foreground: #78716c;
+  --muted: #f5f5f5;
+  --muted-foreground: #64748b;
 
   /* ==========================================
-     ACCENT - Vibrant Violet
+     ACCENT - Vivid Orange
      ========================================== */
-  --accent: #8b5cf6;
+  --accent: #ea580c;
   --accent-foreground: #ffffff;
 
   /* ==========================================
@@ -203,9 +203,9 @@ body {
   /* ==========================================
      BORDERS & INPUTS
      ========================================== */
-  --border: #e7e5e4;
-  --input: #e7e5e4;
-  --ring: #8b5cf6;
+  --border: #e5e7eb;
+  --input: #d1d5db;
+  --ring: #f97316;
 
   /* ==========================================
      FINANCE COLORS - Warm & Friendly
@@ -220,68 +220,68 @@ body {
   /* ==========================================
      CHART COLORS - Vibrant Palette
      ========================================== */
-  --chart-1: #7c3aed;
-  --chart-2: #0d9488;
-  --chart-3: #8b5cf6;
-  --chart-4: #ec4899;
-  --chart-5: #06b6d4;
-  --chart-6: #84cc16;
-  --chart-7: #f43f5e;
-  --chart-8: #6366f1;
+  --chart-1: #ea580c;
+  --chart-2: #0f766e;
+  --chart-3: #475569;
+  --chart-4: #be123c;
+  --chart-5: #0369a1;
+  --chart-6: #4d7c0f;
+  --chart-7: #a16207;
+  --chart-8: #334155;
 
   /* ==========================================
-     SIDEBAR - Vibrant & Modern
+     SIDEBAR
      ========================================== */
-  --sidebar: #faf9f7;
-  --sidebar-foreground: #44403c;
-  --sidebar-primary: #7c3aed;
+  --sidebar: #fafafa;
+  --sidebar-foreground: #334155;
+  --sidebar-primary: #c2410c;
   --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: #f5f3ff;
-  --sidebar-accent-foreground: #5b21b6;
-  --sidebar-border: #e7e5e4;
-  --sidebar-ring: #8b5cf6;
+  --sidebar-accent: #f1f5f9;
+  --sidebar-accent-foreground: #334155;
+  --sidebar-border: #e5e7eb;
+  --sidebar-ring: #f97316;
 }
 
 /* ==========================================
-   WARM & FRIENDLY THEME - Dark Mode
+   TALLYO ORANGE - Dark Mode
    ========================================== */
 
 .dark {
-  /* Background - warm dark with subtle brown undertones */
-  --background: #0c0a09;
-  --foreground: #fafaf9;
+  /* Dark surfaces are distinct without becoming a stack of black panels */
+  --background: #09090b;
+  --foreground: #fafafa;
 
   /* Card - elevated dark for clearer boundaries */
-  --card: #24201e;
-  --card-foreground: #fafaf9;
+  --card: #18181b;
+  --card-foreground: #fafafa;
 
   /* Popover */
-  --popover: #24201e;
-  --popover-foreground: #fafaf9;
+  --popover: #18181b;
+  --popover-foreground: #fafafa;
 
   /* ==========================================
-     PRIMARY - Vibrant Violet
+     PRIMARY - Orange
      ========================================== */
-  --primary: #a78bfa;
-  --primary-foreground: #0c0a09;
+  --primary: #fb923c;
+  --primary-foreground: #2a1205;
 
   /* ==========================================
-     SECONDARY - Dark Purple Tint
+     SECONDARY - Dark Gray
      ========================================== */
-  --secondary: #292524;
-  --secondary-foreground: #d6d3d1;
+  --secondary: #27272a;
+  --secondary-foreground: #e4e4e7;
 
   /* ==========================================
      MUTED - Warm Dark Gray
      ========================================== */
-  --muted: #292524;
-  --muted-foreground: #a8a29e;
+  --muted: #27272a;
+  --muted-foreground: #a1a1aa;
 
   /* ==========================================
-     ACCENT - Vibrant Violet
+     ACCENT - Orange
      ========================================== */
-  --accent: #8b5cf6;
-  --accent-foreground: #ffffff;
+  --accent: #fb923c;
+  --accent-foreground: #2a1205;
 
   /* ==========================================
      DESTRUCTIVE - Soft Red
@@ -292,9 +292,9 @@ body {
   /* ==========================================
      BORDERS & INPUTS
      ========================================== */
-  --border: #292524;
-  --input: #292524;
-  --ring: #8b5cf6;
+  --border: #27272a;
+  --input: #27272a;
+  --ring: #fb923c;
 
   /* ==========================================
      FINANCE COLORS - Dark Mode
@@ -309,26 +309,26 @@ body {
   /* ==========================================
      CHART COLORS - Dark Mode (vibrant)
      ========================================== */
-  --chart-1: #a78bfa;
+  --chart-1: #fb923c;
   --chart-2: #2dd4bf;
-  --chart-3: #f472b6;
+  --chart-3: #fbbf24;
   --chart-4: #fbbf24;
   --chart-5: #22d3ee;
   --chart-6: #a3e635;
   --chart-7: #fb7185;
-  --chart-8: #818cf8;
+  --chart-8: #fdba74;
 
   /* ==========================================
-     SIDEBAR - Dark Vibrant
+     SIDEBAR
      ========================================== */
-  --sidebar: #0c0a09;
-  --sidebar-foreground: #d6d3d1;
-  --sidebar-primary: #a78bfa;
-  --sidebar-primary-foreground: #0c0a09;
-  --sidebar-accent: #292524;
-  --sidebar-accent-foreground: #a78bfa;
-  --sidebar-border: #292524;
-  --sidebar-ring: #8b5cf6;
+  --sidebar: #09090b;
+  --sidebar-foreground: #e4e4e7;
+  --sidebar-primary: #fb923c;
+  --sidebar-primary-foreground: #2a1205;
+  --sidebar-accent: #27272a;
+  --sidebar-accent-foreground: #e4e4e7;
+  --sidebar-border: #27272a;
+  --sidebar-ring: #fb923c;
 
   /* Dark mode shadows - warmer tones */
   --shadow-soft:
@@ -340,8 +340,8 @@ body {
   --shadow-soft-xl:
     0 4px 8px rgba(0, 0, 0, 0.3), 0 12px 24px rgba(0, 0, 0, 0.25),
     0 24px 48px rgba(0, 0, 0, 0.2);
-  --shadow-glow: 0 0 24px rgba(139, 92, 246, 0.25);
-  --shadow-glow-sm: 0 0 16px rgba(139, 92, 246, 0.15);
+  --shadow-glow: 0 0 24px rgba(251, 146, 60, 0.2);
+  --shadow-glow-sm: 0 0 16px rgba(251, 146, 60, 0.12);
 }
 
 @theme inline {
@@ -491,12 +491,12 @@ body {
    ========================================== */
 
 ::selection {
-  background-color: rgba(139, 92, 246, 0.2);
+  background-color: rgba(234, 88, 12, 0.2);
   color: inherit;
 }
 
 .dark ::selection {
-  background-color: rgba(139, 92, 246, 0.3);
+  background-color: rgba(251, 146, 60, 0.28);
 }
 
 html,

--- a/apps/web/src/routes/transactions.tsx
+++ b/apps/web/src/routes/transactions.tsx
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-router";
 import { Plus } from "lucide-react";
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import { z } from "zod";
 import { CreateTransactionForm } from "@/components/transactions/create-transaction-form";
 import { Search } from "@/components/transactions/search";
@@ -400,9 +401,42 @@ function RouteComponent() {
           queryKey: createTransactionQueryOptions(effectiveSearch).queryKey,
         });
         queryClient.invalidateQueries({
+          queryKey: ["dashboard", "getStatsCounts"],
+        });
+        queryClient.invalidateQueries({
           queryKey: ["transactions", "getUserTransactions", "session"],
         });
       },
+    }),
+  );
+
+  const { mutate: createRecurringForecast } = useMutation(
+    orpc.transactions.createRecurringForecast.mutationOptions({
+      onSuccess: () => {
+        toast.success("Monthly forecast added to Period Summary");
+        queryClient.invalidateQueries({
+          queryKey: createTransactionQueryOptions(effectiveSearch).queryKey,
+        });
+        queryClient.invalidateQueries({
+          queryKey: ["dashboard", "getStatsCounts"],
+        });
+      },
+      onError: () => toast.error("Could not add the monthly forecast"),
+    }),
+  );
+
+  const { mutate: removeRecurringForecast } = useMutation(
+    orpc.transactions.removeRecurringForecast.mutationOptions({
+      onSuccess: () => {
+        toast.success("Monthly forecast removed");
+        queryClient.invalidateQueries({
+          queryKey: createTransactionQueryOptions(effectiveSearch).queryKey,
+        });
+        queryClient.invalidateQueries({
+          queryKey: ["dashboard", "getStatsCounts"],
+        });
+      },
+      onError: () => toast.error("Could not remove the monthly forecast"),
     }),
   );
 
@@ -507,6 +541,8 @@ function RouteComponent() {
               updateNotes={updateNotes}
               toggleReviewed={toggleReviewed}
               deleteTransaction={deleteTransaction}
+              createRecurringForecast={createRecurringForecast}
+              removeRecurringForecast={removeRecurringForecast}
               onCategoryClick={handleCategoryClick}
               onMerchantClick={handleMerchantClick}
               isLoading={false}


### PR DESCRIPTION
## Summary
- add monthly recurring forecast rules created from transactions
- show forecasted payments and projected totals in Period Summary
- allow forecast rules to be toggled off and clean them up when source transactions are deleted or split

## Validation
- npm run build
- targeted Biome checks