### PR TITLE
fix(web): remove redundant dashboard transaction navigation

### DIFF
--- a/apps/web/src/components/dashboard/transaction-stats.tsx
+++ b/apps/web/src/components/dashboard/transaction-stats.tsx
@@ -64,27 +64,20 @@ export function TransactionStats({
     );
   }
 
-  const handleTransactionClick = () => {
-    navigate({
-      to: "/transactions",
-    });
-  };
-
   return (
     <div className="space-y-1.5">
       {data.map((transaction) => (
         <Card
           key={transaction.id}
           className="px-3 py-2 sm:px-4 sm:py-3 shadow-sm cursor-pointer hover:bg-muted/50 transition-colors"
-          onClick={() => {
-            handleTransactionClick();
+          onClick={() =>
             navigate({
               to: "/transactions",
               search: {
                 filter: transaction.transactionDetails,
               },
-            });
-          }}
+            })
+          }
           aria-label={`View transaction ${transaction.transactionDetails}`}
         >
           <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary

When clicking a transaction in the dashboard's **Largest Transactions** panel, the handler called `navigate` twice in a row:

1. A bare navigate to `/transactions`
2. Immediately followed by a navigate with the `filter` search param

The first call was dead work — the second call's search params determine the final route. This removes the redundant call so each card performs a single navigation.

## Testing

- `npm run check-types` passes (after building the server)
- `npx biome check apps/web/src/components/dashboard/transaction-stats.tsx` clean