### PR TITLE
fix(turbo): make type-checking work on a fresh clone

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
 	},
 	"devDependencies": {
 		"@tanstack/react-query-devtools": "^5.90.2",
+		"server": "*",
 		"@tanstack/react-router-devtools": "^1.133.34",
 		"@tanstack/router-plugin": "^1.133.32",
 		"@types/d3-sankey": "^0.12.5",

--- a/apps/web/src/components/dashboard/transaction-stats.tsx
+++ b/apps/web/src/components/dashboard/transaction-stats.tsx
@@ -64,27 +64,20 @@ export function TransactionStats({
     );
   }
 
-  const handleTransactionClick = () => {
-    navigate({
-      to: "/transactions",
-    });
-  };
-
   return (
     <div className="space-y-1.5">
       {data.map((transaction) => (
         <Card
           key={transaction.id}
           className="px-3 py-2 sm:px-4 sm:py-3 shadow-sm cursor-pointer hover:bg-muted/50 transition-colors"
-          onClick={() => {
-            handleTransactionClick();
+          onClick={() =>
             navigate({
               to: "/transactions",
               search: {
                 filter: transaction.transactionDetails,
               },
-            });
-          }}
+            })
+          }
           aria-label={`View transaction ${transaction.transactionDetails}`}
         >
           <div className="flex items-center justify-between">

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,6 +123,7 @@
 				"@types/react-dom": "^19.2.2",
 				"@vitejs/plugin-react": "^5.1.0",
 				"postcss": "^8.5.18",
+				"server": "*",
 				"tailwindcss": "^4.1.16",
 				"vite": "^7.3.5"
 			}

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,7 @@
 			"dependsOn": ["^lint"]
 		},
 		"check-types": {
-			"dependsOn": ["^check-types"]
+			"dependsOn": ["^build"]
 		},
 		"dev": {
 			"cache": false,


### PR DESCRIPTION
## Problem

`npm run check-types` failed on a fresh clone (and after any `npm run dev` session, since the server runs via `tsx watch` and never emits `dist/`):

```
apps/web/src/utils/orpc.ts(9,32): error TS6305: Output file
'.../apps/server/dist/src/routers/index.d.ts' has not been built from source file
'.../apps/server/src/routers/index.ts'
```

followed by ~200 cascading errors (`'{}' has no property ...`, `not assignable to parameter of type 'void'`, implicit `any`), all rooted in that single TS6305.

### Root cause

`apps/web/tsconfig.json` declares a project reference to `../server` (introduced in `a0806f2`), so the web `tsc` run needs the server's **built** declaration files. The server `dist/` is gitignored and nothing built it before the web type-check ran, so `check-types` was order-dependent: it only passed if you happened to have a recent server `dist` lying around.

## Fix

1. Declare the real cross-package dependency: add `"server": "*"` to `apps/web` devDependencies. The web app already imports the server router types directly; Turbo just didn't know about the edge, so it could not order web's tasks after server's.
2. In `turbo.json`, make the `check-types` task depend on `^build` (previously `^check-types`, which never emits declarations). Now Turbo runs `server:build` (emitting `dist/**`) before `web:check-types`.

## Verification

With `apps/server/dist` deleted and all Turbo caches bypassed (`npm run check-types -- --force`):

```
server:build        → tsc && tsc-alias && cp ...
server:check-types  → tsc --noEmit
web:check-types     → tsc --noEmit
Tasks:    3 successful, 3 total
```

Also verified `npm run build` (root) and `npx biome check` still pass.