### PR TITLE
chore: resolve biome lint warnings

### DIFF
--- a/apps/server/src/db/index.ts
+++ b/apps/server/src/db/index.ts
@@ -70,7 +70,7 @@ export async function seed() {
       ])
       .returning();
 
-    if (!categories || categories.length !== 7) {
+    if (categories?.length !== 7) {
       throw new Error("Failed to create categories");
     }
   }
@@ -123,7 +123,7 @@ export async function seed() {
       ])
       .returning();
 
-    if (!merchants || merchants.length !== 7) {
+    if (merchants?.length !== 7) {
       throw new Error("Failed to create merchants");
     }
   }

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import {
   deleteSession,
   getDiscordAuthUrl,
@@ -19,7 +19,7 @@ import { logger } from "../lib/logger";
 const CORS_ORIGIN = process.env.CORS_ORIGIN || "";
 const IS_PROD = process.env.NODE_ENV === "production";
 
-function getRedirectOrigin(c: any): string {
+function getRedirectOrigin(c: Context): string {
   if (IS_PROD) return CORS_ORIGIN;
   const origin = c.req.header("origin") || c.req.header("referer");
   if (origin) {
@@ -120,7 +120,7 @@ authRoutes.post("/signout", async (c) => {
   });
 });
 
-function callbackError(c: any, message: string): Response {
+function callbackError(c: Context, message: string): Response {
   const redirectOrigin = getRedirectOrigin(c);
   const headers = new Headers({
     Location: `${redirectOrigin}/signin?error=${encodeURIComponent(message)}`,

--- a/apps/web/src/components/transactions/search.tsx
+++ b/apps/web/src/components/transactions/search.tsx
@@ -1,6 +1,12 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { SlidersHorizontal } from "lucide-react";
-import { type ChangeEvent, useEffect, useRef, useState } from "react";
+import {
+  type ChangeEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { useDebounce } from "@/hooks/use-debounce";
 import { CategorySelect } from "../categories/category-select";
 import { MerchantSelect } from "../merchants/merchant-select";
@@ -20,18 +26,19 @@ export function Search() {
   const navigate = useNavigate();
 
   // Navigation helper
-  const updateSearchParams = (
-    updates: Record<string, string | boolean | null | undefined>,
-  ) => {
-    navigate({
-      to: "/transactions",
-      search: (prev) => ({
-        ...prev,
-        ...updates,
-        page: 1, // Reset to first page when filters change
-      }),
-    });
-  };
+  const updateSearchParams = useCallback(
+    (updates: Record<string, string | boolean | null | undefined>) => {
+      navigate({
+        to: "/transactions",
+        search: (prev) => ({
+          ...prev,
+          ...updates,
+          page: 1, // Reset to first page when filters change
+        }),
+      });
+    },
+    [navigate],
+  );
 
   // Only maintain local state for the search input (debounced)
   const [filter, setFilter] = useState(() => params.filter ?? "");
@@ -46,7 +53,7 @@ export function Search() {
         updateSearchParams({ filter: debouncedFilter });
       }
     }
-  }, [debouncedFilter, params.filter]);
+  }, [debouncedFilter, params.filter, updateSearchParams]);
 
   // UI state
   const [isOpenMobile, setIsOpenMobile] = useState(false);

--- a/apps/web/src/components/transactions/transactions-table.tsx
+++ b/apps/web/src/components/transactions/transactions-table.tsx
@@ -930,14 +930,18 @@ export function TransactionsTable({
                             size="sm"
                             className="w-full justify-start text-left font-normal text-xs h-7"
                             disabled={isLoading}
-                            onClick={() =>
-                              handleMerchantChange(
-                                transaction.id,
+                            onClick={() => {
+                              const suggested =
                                 suggestedMerchantByTransactionId.get(
                                   transaction.id,
-                                )!.id,
-                              )
-                            }
+                                );
+                              if (suggested) {
+                                handleMerchantChange(
+                                  transaction.id,
+                                  suggested.id,
+                                );
+                              }
+                            }}
                           >
                             <span className="truncate">
                               Use suggested merchant:{" "}
@@ -945,7 +949,7 @@ export function TransactionsTable({
                                 {
                                   suggestedMerchantByTransactionId.get(
                                     transaction.id,
-                                  )!.name
+                                  )?.name
                                 }
                               </span>
                             </span>

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",


### PR DESCRIPTION
## Summary

Clears the 6 warnings / 2 infos reported by `npm run check`:

- **biome.json** — bump `` from 2.4.13 to 2.4.16 (matches CLI version)
- **apps/server/src/routes/auth.ts** — replace `any` params with Hono's `Context` type in `getRedirectOrigin` and `callbackError` (`noExplicitAny`)
- **apps/server/src/db/index.ts** — simplify null guards to optional chains in seed helpers (`useOptionalChain`)
- **apps/web/src/components/transactions/search.tsx** — wrap `updateSearchParams` in `useCallback` and add it to the debounce effect's deps (`useExhaustiveDependencies`)
- **apps/web/src/components/transactions/transactions-table.tsx** — replace `!.id` / `!.name` on the suggested-merchant lookup with a guarded lookup and optional chaining (`noNonNullAssertion`)

## Verification

- `npm run check` — 103 files, no warnings/infos
- `npm run check-types -- --force` with `apps/server/dist` removed — 3/3 tasks pass