### PR TITLE
chore(server): remove unused dashboard computations

### DIFF
--- a/apps/server/src/routers/dashboard.ts
+++ b/apps/server/src/routers/dashboard.ts
@@ -15,7 +15,7 @@ import {
 } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/db";
-import { category, merchant, merchantKeyword, transaction } from "@/db/schema";
+import { category, merchant, transaction } from "@/db/schema";
 import { protectedProcedure } from "../lib/orpc";
 
 const dateRangeSchema = z.object({
@@ -28,31 +28,6 @@ const dateRangeSchema = z.object({
     .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be in YYYY-MM-DD format")
     .optional(),
 });
-
-// Helper function to calculate standard deviation
-function calculateStandardDeviation(values: number[]): number {
-  if (values.length === 0) return 0;
-
-  const mean = values.reduce((sum, val) => sum + val, 0) / values.length;
-  const squaredDifferences = values.map((val) => (val - mean) ** 2);
-  const variance =
-    squaredDifferences.reduce((sum, val) => sum + val, 0) / values.length;
-
-  return Math.sqrt(variance);
-}
-
-// Helper function to calculate volatility
-function _calculateVolatility(values: number[]): number {
-  if (values.length === 0) return 0;
-
-  // Treat all values as absolute for volatility
-  const absValues = values.map(Math.abs);
-  const mean = absValues.reduce((sum, val) => sum + val, 0) / absValues.length;
-  if (mean === 0) return 0;
-
-  const standardDeviation = calculateStandardDeviation(absValues);
-  return (standardDeviation / mean) * 100;
-}
 
 type StatsDateRange = { from?: string; to?: string };
 
@@ -170,13 +145,8 @@ async function getStatsForDateRange(
 ): Promise<{
   stats: {
     totalTransactions: number;
-    totalCategories: number;
-    totalMerchants: number;
-    totalMerchantKeywords: number;
     totalExpenses: number;
     totalIncome: number;
-    totalIncomeTransactions: number;
-    totalExpenseTransactions: number;
     avgIncomeTransactionsPerMonth: number;
     avgExpenseTransactionsPerMonth: number;
     avgIncomeAmountPerMonth: number;
@@ -189,9 +159,6 @@ async function getStatsForDateRange(
 }> {
   const [
     transactionCount,
-    categoryCount,
-    merchantCount,
-    merchantKeywordCount,
     expenseCount,
     incomeCount,
     expenseTransactionCount,
@@ -211,18 +178,6 @@ async function getStatsForDateRange(
           ...(dateRange.to ? [lte(transaction.date, dateRange.to)] : []),
         ),
       ),
-    db
-      .select({ count: count() })
-      .from(category)
-      .where(eq(category.userId, userId)),
-    db
-      .select({ count: count() })
-      .from(merchant)
-      .where(eq(merchant.userId, userId)),
-    db
-      .select({ count: count() })
-      .from(merchantKeyword)
-      .where(eq(merchantKeyword.userId, userId)),
     db
       .select({ amount: sum(transaction.amount) })
       .from(transaction)
@@ -479,14 +434,6 @@ async function getStatsForDateRange(
         transactionCount.status === "fulfilled"
           ? transactionCount.value[0].count
           : 0,
-      totalCategories:
-        categoryCount.status === "fulfilled" ? categoryCount.value[0].count : 0,
-      totalMerchants:
-        merchantCount.status === "fulfilled" ? merchantCount.value[0].count : 0,
-      totalMerchantKeywords:
-        merchantKeywordCount.status === "fulfilled"
-          ? merchantKeywordCount.value[0].count
-          : 0,
       totalExpenses:
         expenseCount.status === "fulfilled" && expenseCount.value[0].amount
           ? Number(expenseCount.value[0].amount)
@@ -494,14 +441,6 @@ async function getStatsForDateRange(
       totalIncome:
         incomeCount.status === "fulfilled" && incomeCount.value[0].amount
           ? Number(incomeCount.value[0].amount)
-          : 0,
-      totalIncomeTransactions:
-        incomeTransactionCount.status === "fulfilled"
-          ? incomeTransactionCount.value[0].count
-          : 0,
-      totalExpenseTransactions:
-        expenseTransactionCount.status === "fulfilled"
-          ? expenseTransactionCount.value[0].count
           : 0,
       avgIncomeTransactionsPerMonth: avgIncomeTransactions,
       avgExpenseTransactionsPerMonth: avgExpenseTransactions,

--- a/apps/server/src/routers/meta.ts
+++ b/apps/server/src/routers/meta.ts
@@ -1,14 +1,7 @@
 import { addDays, format } from "date-fns";
-import { and, asc, count, desc, eq, lte } from "drizzle-orm";
+import { and, asc, count, eq, lte } from "drizzle-orm";
 import { db } from "@/db";
-import {
-  account,
-  category,
-  merchant,
-  settings,
-  transaction,
-  user,
-} from "@/db/schema";
+import { account, settings, transaction } from "@/db/schema";
 import { protectedProcedure } from "../lib/orpc";
 
 export const metaRouter = {
@@ -105,39 +98,12 @@ export const metaRouter = {
     };
   }),
   getUserMeta: protectedProcedure.handler(async ({ context }) => {
-    const topFiveCategories = await db.query.category.findMany({
-      where: eq(category.userId, context.session?.user?.id),
-      orderBy: [desc(category.name)],
-      limit: 5,
-    });
-
-    const topFiveMerchants = await db.query.merchant.findMany({
-      where: eq(merchant.userId, context.session?.user?.id),
-      orderBy: [desc(merchant.name)],
-      limit: 5,
-    });
-
-    const userCreatedAt = await db.query.user.findFirst({
-      where: eq(user.id, context.session?.user?.id),
-      columns: {
-        createdAt: true,
-      },
-    });
-
     const earliestTransactionDate = await db.query.transaction.findFirst({
       where: eq(transaction.userId, context.session?.user?.id),
       orderBy: [asc(transaction.date)],
       columns: {
         date: true,
       },
-    });
-
-    const transferCategoryId = await db.query.category.findFirst({
-      where: and(
-        eq(category.userId, context.session?.user?.id),
-        eq(category.hideFromInsights, true),
-        eq(category.name, "Transfer"),
-      ),
     });
 
     const unreviewedTransactionCount = await db
@@ -152,10 +118,6 @@ export const metaRouter = {
       );
 
     return {
-      topFiveCategories,
-      topFiveMerchants,
-      userCreatedAt: userCreatedAt?.createdAt,
-      transferCategoryId: transferCategoryId?.id ?? null,
       earliestTransactionDate:
         earliestTransactionDate?.date ?? format(new Date(), "yyyy-MM-dd"),
       unreviewedTransactionCount: unreviewedTransactionCount[0]?.count ?? 0,


### PR DESCRIPTION
## Summary

Cleans up code computed by the dashboard/meta routers that is never surfaced anywhere in the web app. Reduces the session payload and dashboard stats response while keeping the queries that feed live insights.

## Changes

`apps/server/src/routers/dashboard.ts`
- Removed dead `calculateStandardDeviation` / `_calculateVolatility` helpers (never invoked)
- Dropped unused `getStatsForDateRange` output fields and their backing queries: `totalCategories`, `totalMerchants`, `totalMerchantKeywords`, `totalIncomeTransactions`, `totalExpenseTransactions`
- Kept the `incomeTransactionCount` / `expenseTransactionCount` queries, which still feed the monthly-average fallback used by Period insights

`apps/server/src/routers/meta.ts`
- Removed unused `getUserMeta` fields and their queries: `topFiveCategories`, `topFiveMerchants`, `userCreatedAt`, `transferCategoryId`
- Kept `earliestTransactionDate` (used by the date-range picker "All time" preset) and `unreviewedTransactionCount` (dashboard banner)

## Verification

- `npm run check-types` passes (server + web; web compiles against the narrowed oRPC contract)
- `npx biome check` passes on both edited files
- No remaining references to removed fields in the repo