### PR TITLE
feat(dashboard): add prior-period comparison insights

### DIFF
--- a/apps/server/src/routers/dashboard.ts
+++ b/apps/server/src/routers/dashboard.ts
@@ -1,3 +1,4 @@
+import { format } from "date-fns";
 import {
   and,
   asc,
@@ -762,5 +763,132 @@ export const dashboardRouter = {
     .input(dateRangeSchema.optional())
     .handler(async ({ context, input }) => {
       return getStatsForDateRange(context.session.user.id, input || {});
+    }),
+  getPeriodComparison: protectedProcedure
+    .input(dateRangeSchema.optional())
+    .handler(async ({ context, input }) => {
+      const dateRange = input || {};
+      const userId = context.session.user.id;
+
+      if (!dateRange.from || !dateRange.to) {
+        return {
+          hasPrevious: false,
+          totals: null,
+          categories: [],
+          merchants: [],
+        };
+      }
+
+      const fromDate = new Date(dateRange.from);
+      const toDate = new Date(dateRange.to);
+      const periodLength =
+        Math.ceil(
+          Math.abs(toDate.getTime() - fromDate.getTime()) /
+            (1000 * 60 * 60 * 24),
+        ) + 1;
+
+      const prevFromDate = new Date(fromDate);
+      prevFromDate.setDate(prevFromDate.getDate() - periodLength);
+      const prevToDate = new Date(fromDate);
+      prevToDate.setDate(prevToDate.getDate() - 1);
+
+      const prevFrom = format(prevFromDate, "yyyy-MM-dd");
+      const prevTo = format(prevToDate, "yyyy-MM-dd");
+
+      const [income, expenses, txCount, categories, merchants] =
+        await Promise.all([
+          db
+            .select({ amount: sum(transaction.amount) })
+            .from(transaction)
+            .innerJoin(category, eq(transaction.categoryId, category.id))
+            .where(
+              and(
+                eq(transaction.userId, userId),
+                eq(transaction.reviewed, true),
+                eq(category.treatAsIncome, true),
+                eq(category.hideFromInsights, false),
+                gte(transaction.date, prevFrom),
+                lte(transaction.date, prevTo),
+              ),
+            ),
+          db
+            .select({ amount: sum(transaction.amount) })
+            .from(transaction)
+            .innerJoin(category, eq(transaction.categoryId, category.id))
+            .where(
+              and(
+                eq(transaction.userId, userId),
+                eq(transaction.reviewed, true),
+                eq(category.treatAsIncome, false),
+                eq(category.hideFromInsights, false),
+                gte(transaction.date, prevFrom),
+                lte(transaction.date, prevTo),
+              ),
+            ),
+          db
+            .select({ count: count() })
+            .from(transaction)
+            .where(
+              and(
+                eq(transaction.userId, userId),
+                gte(transaction.date, prevFrom),
+                lte(transaction.date, prevTo),
+              ),
+            ),
+          db
+            .select({
+              categoryId: category.id,
+              amount: sum(transaction.amount),
+            })
+            .from(transaction)
+            .innerJoin(category, eq(transaction.categoryId, category.id))
+            .where(
+              and(
+                eq(transaction.userId, userId),
+                eq(transaction.reviewed, true),
+                eq(category.treatAsIncome, false),
+                eq(category.hideFromInsights, false),
+                gte(transaction.date, prevFrom),
+                lte(transaction.date, prevTo),
+              ),
+            )
+            .groupBy(category.id),
+          db
+            .select({
+              merchantId: merchant.id,
+              totalAmount: sum(transaction.amount),
+            })
+            .from(transaction)
+            .innerJoin(merchant, eq(transaction.merchantId, merchant.id))
+            .innerJoin(category, eq(transaction.categoryId, category.id))
+            .where(
+              and(
+                eq(transaction.userId, userId),
+                eq(transaction.reviewed, true),
+                eq(category.hideFromInsights, false),
+                not(eq(category.treatAsIncome, true)),
+                gte(transaction.date, prevFrom),
+                lte(transaction.date, prevTo),
+              ),
+            )
+            .groupBy(merchant.id),
+        ]);
+
+      return {
+        hasPrevious: true,
+        totals: {
+          totalIncome: Math.abs(Number(income[0]?.amount ?? 0)),
+          totalExpenses: Math.abs(Number(expenses[0]?.amount ?? 0)),
+          totalTransactions: txCount[0]?.count ?? 0,
+        },
+        categories: categories.map((row) => ({
+          categoryId: row.categoryId,
+          amount: Math.abs(Number(row.amount ?? 0)),
+        })),
+        merchants: merchants.map((row) => ({
+          merchantId: row.merchantId,
+          totalAmount: Math.abs(Number(row.totalAmount ?? 0)),
+        })),
+      };
     }),
 };

--- a/apps/server/src/routers/index.ts
+++ b/apps/server/src/routers/index.ts
@@ -45,6 +45,10 @@ export type DashboardSankeyData = InferRouterOutputs<
   typeof dashboardRouter
 >["getSankeyData"];
 
+export type DashboardPeriodComparison = InferRouterOutputs<
+  typeof dashboardRouter
+>["getPeriodComparison"];
+
 export const appRouter = {
   healthCheck: publicProcedure.handler(async () => {
     try {

--- a/apps/web/src/components/dashboard/category-pie-chart.tsx
+++ b/apps/web/src/components/dashboard/category-pie-chart.tsx
@@ -5,7 +5,10 @@ import { ChevronDown } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { CurrencyAmount } from "@/components/ui/currency-amount";
-import type { DashboardCategoryData } from "../../../../server/src/routers";
+import type {
+  DashboardCategoryData,
+  DashboardPeriodComparison,
+} from "../../../../server/src/routers";
 import { formatCategoryText } from "../categories/category-select";
 
 const chartColors = [
@@ -45,12 +48,26 @@ interface ChartItem {
   categoryId: string;
 }
 
-export function CategoryPieChart({ data }: { data: DashboardCategoryData }) {
+export function CategoryPieChart({
+  data,
+  previous,
+}: {
+  data: DashboardCategoryData;
+  previous?: DashboardPeriodComparison["categories"];
+}) {
   const [activeItemId, setActiveItemId] = useState<string | null>(null);
   const [hasLegendOverflow, setHasLegendOverflow] = useState(false);
   const [isScrolledToBottom, setIsScrolledToBottom] = useState(false);
   const legendRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
+
+  const previousMap = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const item of previous ?? []) {
+      map.set(item.categoryId, item.amount);
+    }
+    return map;
+  }, [previous]);
 
   // Process all data - no grouping
   const chartData = useMemo<ChartItem[]>(() => {
@@ -245,6 +262,9 @@ export function CategoryPieChart({ data }: { data: DashboardCategoryData }) {
                     ? ((item.value / totalAmount) * 100).toFixed(1)
                     : "0.0";
                 const isActive = activeItemId === item.id;
+                const prevAmount = previousMap.get(item.categoryId);
+                const delta =
+                  prevAmount === undefined ? null : item.value - prevAmount;
                 return (
                   <button
                     key={item.id}
@@ -268,6 +288,27 @@ export function CategoryPieChart({ data }: { data: DashboardCategoryData }) {
                       <span className="text-xs text-muted-foreground tabular-nums">
                         <CurrencyAmount amount={item.value} /> ({percentage}%)
                       </span>
+                      {delta !== null && (
+                        <span
+                          className={`text-[11px] tabular-nums ${
+                            delta > 0
+                              ? "text-expense"
+                              : delta < 0
+                                ? "text-income"
+                                : "text-muted-foreground"
+                          }`}
+                        >
+                          {delta === 0 ? (
+                            "Same as last period"
+                          ) : (
+                            <>
+                              {delta > 0 ? "▲" : "▼"}{" "}
+                              <CurrencyAmount amount={Math.abs(delta)} /> vs
+                              last period
+                            </>
+                          )}
+                        </span>
+                      )}
                     </div>
                   </button>
                 );

--- a/apps/web/src/components/dashboard/merchant-stats.tsx
+++ b/apps/web/src/components/dashboard/merchant-stats.tsx
@@ -1,16 +1,25 @@
 import { useNavigate } from "@tanstack/react-router";
 import { StoreIcon } from "lucide-react";
-import type { DashboardMerchantStats } from "../../../../server/src/routers";
+import type {
+  DashboardMerchantStats,
+  DashboardPeriodComparison,
+} from "../../../../server/src/routers";
 import { Card } from "../ui/card";
 import { CardListEmpty } from "../ui/card-list";
 import { CurrencyAmount } from "../ui/currency-amount";
 
 export function MerchantStats({
   data,
+  previous,
 }: {
   data: DashboardMerchantStats | undefined;
+  previous?: DashboardPeriodComparison["merchants"];
 }) {
   const navigate = useNavigate();
+
+  const previousTotals = new Map(
+    (previous ?? []).map((item) => [item.merchantId, item.totalAmount]),
+  );
 
   if (!data || data.length === 0) {
     return (
@@ -31,33 +40,56 @@ export function MerchantStats({
 
   return (
     <div className="space-y-1.5">
-      {data.map((merchant) => (
-        <Card
-          key={merchant.merchantId}
-          className="px-3 py-2 sm:px-4 sm:py-3 shadow-sm cursor-pointer hover:bg-muted/50 transition-colors"
-          onClick={() => handleMerchantClick(merchant.merchantId)}
-          aria-label={`View transactions for ${merchant.merchantName}`}
-        >
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <div className="p-1.5 rounded-md bg-accent/10">
-                <StoreIcon className="w-3.5 h-3.5 text-accent" />
+      {data.map((merchant) => {
+        const current = Math.abs(Number(merchant.totalAmount));
+        const prevTotal = previousTotals.get(merchant.merchantId);
+        const changePct =
+          prevTotal === undefined || prevTotal === 0
+            ? null
+            : Math.round(((current - prevTotal) / prevTotal) * 100);
+        return (
+          <Card
+            key={merchant.merchantId}
+            className="px-3 py-2 sm:px-4 sm:py-3 shadow-sm cursor-pointer hover:bg-muted/50 transition-colors"
+            onClick={() => handleMerchantClick(merchant.merchantId)}
+            aria-label={`View transactions for ${merchant.merchantName}`}
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <div className="p-1.5 rounded-md bg-accent/10">
+                  <StoreIcon className="w-3.5 h-3.5 text-accent" />
+                </div>
+                <div>
+                  <p className="font-medium text-xs sm:text-sm">
+                    {merchant.merchantName}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {merchant.count} transaction
+                    {merchant.count !== 1 ? "s" : ""}
+                    {changePct !== null && (
+                      <span
+                        className={`ml-1.5 ${
+                          changePct > 0
+                            ? "text-expense"
+                            : changePct < 0
+                              ? "text-income"
+                              : "text-muted-foreground"
+                        }`}
+                      >
+                        {changePct > 0 ? "▲" : changePct < 0 ? "▼" : "—"}{" "}
+                        {Math.abs(changePct)}% vs last period
+                      </span>
+                    )}
+                  </p>
+                </div>
               </div>
-              <div>
-                <p className="font-medium text-xs sm:text-sm">
-                  {merchant.merchantName}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {merchant.count} transaction{merchant.count !== 1 ? "s" : ""}
-                </p>
+              <div className="text-right">
+                <CurrencyAmount animate amount={Number(merchant.totalAmount)} />
               </div>
             </div>
-            <div className="text-right">
-              <CurrencyAmount animate amount={Number(merchant.totalAmount)} />
-            </div>
-          </div>
-        </Card>
-      ))}
+          </Card>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/src/components/dashboard/period-insights.tsx
+++ b/apps/web/src/components/dashboard/period-insights.tsx
@@ -7,9 +7,14 @@ import {
   TrendingUpIcon,
 } from "lucide-react";
 import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { CurrencyAmount } from "@/components/ui/currency-amount";
-import type { DashboardStats } from "../../../../server/src/routers";
+import { cn } from "@/lib/utils";
+import type {
+  DashboardPeriodComparison,
+  DashboardStats,
+} from "../../../../server/src/routers";
 
 const DAYS_PER_MONTH = 30;
 const INSIGHTS_TABLE_COLUMNS = "grid-cols-[minmax(0,1fr)_130px_110px]";
@@ -93,7 +98,18 @@ function InsightsHeaderRow() {
   );
 }
 
-export function PeriodInsights({ data }: { data: DashboardStats | undefined }) {
+export function PeriodInsights({
+  data,
+  previous,
+}: {
+  data: DashboardStats | undefined;
+  previous?: DashboardPeriodComparison["totals"];
+}) {
+  const [basis, setBasis] = useState<"average" | "previous">("average");
+  useEffect(() => {
+    if (!previous) setBasis("average");
+  }, [previous]);
+
   if (!data?.stats) {
     return (
       <Card className="border-dashed border-border/80 bg-muted/20 p-4 sm:p-5">
@@ -107,6 +123,9 @@ export function PeriodInsights({ data }: { data: DashboardStats | undefined }) {
   const s = data.stats;
   const periodDays = s.periodLengthInDays ?? DAYS_PER_MONTH;
   const scale = periodDays / DAYS_PER_MONTH;
+
+  const hasPrevious = previous != null;
+  const usePrevious = hasPrevious && basis === "previous";
 
   const incomeCur = Number(s.totalIncome) || 0;
   const expensesCur = Math.abs(Number(s.totalExpenses) || 0);
@@ -124,16 +143,19 @@ export function PeriodInsights({ data }: { data: DashboardStats | undefined }) {
     s.avgExpenseForWindow != null ||
     s.avgTransactionCountForWindow != null;
 
-  const expectedIncome =
-    useWindow && s.avgIncomeForWindow != null
+  const expectedIncome = usePrevious
+    ? Number(previous?.totalIncome) || 0
+    : useWindow && s.avgIncomeForWindow != null
       ? Number(s.avgIncomeForWindow)
       : scaledMonthlyIncome;
-  const expectedExpenses =
-    useWindow && s.avgExpenseForWindow != null
+  const expectedExpenses = usePrevious
+    ? Number(previous?.totalExpenses) || 0
+    : useWindow && s.avgExpenseForWindow != null
       ? Number(s.avgExpenseForWindow)
       : scaledMonthlyExpense;
-  const expectedTxScaled =
-    useWindow && s.avgTransactionCountForWindow != null
+  const expectedTxScaled = usePrevious
+    ? Number(previous?.totalTransactions) || 0
+    : useWindow && s.avgTransactionCountForWindow != null
       ? Number(s.avgTransactionCountForWindow)
       : scaledMonthlyTx;
 
@@ -176,12 +198,41 @@ export function PeriodInsights({ data }: { data: DashboardStats | undefined }) {
     <Card className="border-border/80 bg-card/90 p-4 sm:p-5 shadow-sm">
       <div className="mb-3">
         <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-          Vs your average
+          {usePrevious ? "Vs previous period" : "Vs your average"}
         </h3>
         <p className="text-xs text-muted-foreground mt-1">
           Snapshot for this selected period
         </p>
       </div>
+
+      {hasPrevious && (
+        <div className="mb-3 flex w-fit items-center gap-1 rounded-lg bg-muted/60 p-0.5">
+          <button
+            type="button"
+            onClick={() => setBasis("average")}
+            className={cn(
+              "px-2.5 py-1 rounded-md text-xs font-medium transition-colors cursor-pointer",
+              basis === "average"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            vs Average
+          </button>
+          <button
+            type="button"
+            onClick={() => setBasis("previous")}
+            className={cn(
+              "px-2.5 py-1 rounded-md text-xs font-medium transition-colors cursor-pointer",
+              basis === "previous"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            vs Previous period
+          </button>
+        </div>
+      )}
 
       <div className="border-y border-border/40">
         <div className="divide-y divide-border/40">
@@ -250,9 +301,11 @@ export function PeriodInsights({ data }: { data: DashboardStats | undefined }) {
       </div>
 
       <p className="text-xs text-muted-foreground mt-2">
-        {useWindow
-          ? "Based on your typical results for a similar window."
-          : "Based on your average monthly pace."}
+        {usePrevious
+          ? "Based on the previous period."
+          : useWindow
+            ? "Based on your typical results for a similar window."
+            : "Based on your average monthly pace."}
       </p>
     </Card>
   );

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -75,6 +75,11 @@ export const Route = createFileRoute("/dashboard")({
           input: dateRangeToApiFormat(dateRange),
         }),
       ),
+      context.queryClient.prefetchQuery(
+        orpc.dashboard.getPeriodComparison.queryOptions({
+          input: dateRangeToApiFormat(dateRange),
+        }),
+      ),
     ]);
   },
 });
@@ -155,12 +160,20 @@ function RouteComponent() {
     }),
   );
 
+  const { data: periodData, isLoading: isPeriodLoading } = useQuery(
+    orpc.dashboard.getPeriodComparison.queryOptions({
+      placeholderData: (previousData) => previousData,
+      input: dateRangeToApiFormat(dateRange),
+    }),
+  );
+
   const isLoading =
     isStatsLoading ||
     isCategoryLoading ||
     isMerchantLoading ||
     isTransactionLoading ||
-    isSankeyLoading;
+    isSankeyLoading ||
+    isPeriodLoading;
 
   return (
     <div className="min-h-full overflow-x-hidden">
@@ -189,11 +202,17 @@ function RouteComponent() {
             </SectionPanel>
 
             <SectionPanel title="Spending breakdown">
-              <DashboardCharts categoryData={categoryData} />
+              <DashboardCharts
+                categoryData={categoryData}
+                previousCategories={periodData?.categories ?? []}
+              />
             </SectionPanel>
 
             <SectionPanel title="Period insights">
-              <PeriodInsights data={statsData} />
+              <PeriodInsights
+                data={statsData}
+                previous={periodData?.totals ?? null}
+              />
             </SectionPanel>
 
             <SectionPanel title="Income flow">
@@ -204,6 +223,7 @@ function RouteComponent() {
           <DashboardDetails
             merchantData={merchantData}
             transactionData={transactionData}
+            previousMerchants={periodData?.merchants ?? []}
           />
         </div>
       </DelayedLoading>
@@ -280,17 +300,23 @@ function DashboardHeader({
   );
 }
 
+type PeriodComparison = Awaited<
+  ReturnType<typeof orpc.dashboard.getPeriodComparison.call>
+>;
+
 function DashboardCharts({
   categoryData,
+  previousCategories,
 }: {
   categoryData:
     | Awaited<ReturnType<typeof orpc.dashboard.getCategoryData.call>>
     | undefined;
+  previousCategories: PeriodComparison["categories"];
 }) {
   return (
     <>
       {categoryData && categoryData.length > 0 ? (
-        <CategoryPieChart data={categoryData} />
+        <CategoryPieChart data={categoryData} previous={previousCategories} />
       ) : (
         <div className="min-h-[250px] sm:min-h-[300px] flex items-center justify-center text-muted-foreground text-sm rounded-xl bg-muted/40">
           No category data
@@ -323,6 +349,7 @@ function DashboardSankey({
 function DashboardDetails({
   merchantData,
   transactionData,
+  previousMerchants,
 }: {
   merchantData:
     | Awaited<ReturnType<typeof orpc.dashboard.getMerchantStats.call>>
@@ -330,6 +357,7 @@ function DashboardDetails({
   transactionData:
     | Awaited<ReturnType<typeof orpc.dashboard.getTransactionStats.call>>
     | undefined;
+  previousMerchants: PeriodComparison["merchants"];
 }) {
   return (
     <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
@@ -338,7 +366,7 @@ function DashboardDetails({
           <SectionTitle>Top Merchants</SectionTitle>
         </div>
         {merchantData && merchantData.length > 0 ? (
-          <MerchantStats data={merchantData} />
+          <MerchantStats data={merchantData} previous={previousMerchants} />
         ) : (
           <div className="p-6 sm:p-8 text-center text-muted-foreground text-sm rounded-xl bg-muted/40">
             No merchant data


### PR DESCRIPTION
## Summary

Adds a new `getPeriodComparison` dashboard procedure that computes income, expenses, transaction count, per-category, and per-merchant aggregates for the window immediately preceding the selected date range. The dashboard surfaces these as deltas across three widgets.

## Changes

`apps/server/src/routers/dashboard.ts`
- New `getPeriodComparison` procedure: given `from`/`to`, computes the previous period (`[from - length, from - 1d]`) and returns `hasPrevious`, `totals` (income/expenses/tx count), `categories` (id → amount), and `merchants` (id → amount). Returns `hasPrevious: false` when no range is selected (e.g. all time).

`apps/server/src/routers/index.ts`
- Exports `DashboardPeriodComparison` type.

`apps/web/src/routes/dashboard.tsx`
- Prefetches and queries `getPeriodComparison`, threads the data into Period insights, Spending breakdown, and Top merchants.

`apps/web/src/components/dashboard/period-insights.tsx`
- Adds a segmented toggle (`vs Average` / `vs Previous period`) that switches the comparison basis for the Income/Expenses/Transactions/Savings Rate rows. Footer note and heading update accordingly.

`apps/web/src/components/dashboard/category-pie-chart.tsx`
- Legend items show a per-category delta vs the previous period (▲/▼ + amount, or "Same as last period"), privacy-aware via `CurrencyAmount`.

`apps/web/src/components/dashboard/merchant-stats.tsx`
- Each merchant row shows its % change vs the previous period (▲/▼, colored).

All new props are optional, so widgets render unchanged when no previous period exists.

## Verification

- `npm run check-types` passes (server + web)
- `npx biome check` passes on all edited files