### PR TITLE
feat(dashboard): add data-quality card

### DIFF
--- a/apps/server/src/routers/dashboard.ts
+++ b/apps/server/src/routers/dashboard.ts
@@ -830,4 +830,57 @@ export const dashboardRouter = {
         })),
       };
     }),
+  getDataQuality: protectedProcedure
+    .input(dateRangeSchema.optional())
+    .handler(async ({ context, input }) => {
+      const dateRange = input || {};
+      const userId = context.session.user.id;
+
+      const [total, reviewed, uncategorized] = await Promise.all([
+        db
+          .select({ count: count() })
+          .from(transaction)
+          .where(
+            and(
+              eq(transaction.userId, userId),
+              ...(dateRange.from
+                ? [gte(transaction.date, dateRange.from)]
+                : []),
+              ...(dateRange.to ? [lte(transaction.date, dateRange.to)] : []),
+            ),
+          ),
+        db
+          .select({ count: count() })
+          .from(transaction)
+          .where(
+            and(
+              eq(transaction.userId, userId),
+              eq(transaction.reviewed, true),
+              ...(dateRange.from
+                ? [gte(transaction.date, dateRange.from)]
+                : []),
+              ...(dateRange.to ? [lte(transaction.date, dateRange.to)] : []),
+            ),
+          ),
+        db
+          .select({ count: count() })
+          .from(transaction)
+          .where(
+            and(
+              eq(transaction.userId, userId),
+              isNull(transaction.categoryId),
+              ...(dateRange.from
+                ? [gte(transaction.date, dateRange.from)]
+                : []),
+              ...(dateRange.to ? [lte(transaction.date, dateRange.to)] : []),
+            ),
+          ),
+      ]);
+
+      return {
+        totalTransactions: total[0]?.count ?? 0,
+        reviewedTransactions: reviewed[0]?.count ?? 0,
+        uncategorizedTransactions: uncategorized[0]?.count ?? 0,
+      };
+    }),
 };

--- a/apps/server/src/routers/index.ts
+++ b/apps/server/src/routers/index.ts
@@ -49,6 +49,10 @@ export type DashboardPeriodComparison = InferRouterOutputs<
   typeof dashboardRouter
 >["getPeriodComparison"];
 
+export type DashboardDataQuality = InferRouterOutputs<
+  typeof dashboardRouter
+>["getDataQuality"];
+
 export const appRouter = {
   healthCheck: publicProcedure.handler(async () => {
     try {

--- a/apps/web/src/components/dashboard/data-quality-card.tsx
+++ b/apps/web/src/components/dashboard/data-quality-card.tsx
@@ -1,0 +1,72 @@
+import { CheckCircle2, Eye, Tag } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import type { DashboardDataQuality } from "../../../../server/src/routers";
+
+export function DataQualityCard({
+  data,
+}: {
+  data: DashboardDataQuality | undefined;
+}) {
+  if (!data || data.totalTransactions === 0) {
+    return null;
+  }
+
+  const { totalTransactions, reviewedTransactions, uncategorizedTransactions } =
+    data;
+  const unreviewed = totalTransactions - reviewedTransactions;
+  const reviewedPct =
+    totalTransactions > 0
+      ? Math.round((reviewedTransactions / totalTransactions) * 100)
+      : 0;
+
+  return (
+    <Card className="border-border/80 bg-card/90 p-4 sm:p-5 shadow-sm">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-md bg-income/10">
+            <CheckCircle2 className="h-4 w-4 text-income" />
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground uppercase tracking-wider">
+              Reviewed
+            </p>
+            <p className="text-lg font-semibold tabular-nums">{reviewedPct}%</p>
+            <p className="text-xs text-muted-foreground">
+              {reviewedTransactions} of {totalTransactions} transactions
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-md bg-accent/10">
+            <Eye className="h-4 w-4 text-accent" />
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground uppercase tracking-wider">
+              Unreviewed
+            </p>
+            <p className="text-lg font-semibold tabular-nums">{unreviewed}</p>
+            <p className="text-xs text-muted-foreground">In this period</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-md bg-amber-500/10">
+            <Tag className="h-4 w-4 text-amber-500" />
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground uppercase tracking-wider">
+              Uncategorized
+            </p>
+            <p className="text-lg font-semibold tabular-nums">
+              {uncategorizedTransactions}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Transactions without a category
+            </p>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -10,6 +10,7 @@ import { type ReactNode, useMemo } from "react";
 import type { DateRange } from "react-day-picker";
 import { z } from "zod";
 import { CategoryPieChart } from "@/components/dashboard/category-pie-chart";
+import { DataQualityCard } from "@/components/dashboard/data-quality-card";
 import { IncomeExpenseSankey } from "@/components/dashboard/income-expense-sankey";
 import { MerchantStats } from "@/components/dashboard/merchant-stats";
 import { PeriodInsights } from "@/components/dashboard/period-insights";
@@ -77,6 +78,11 @@ export const Route = createFileRoute("/dashboard")({
       ),
       context.queryClient.prefetchQuery(
         orpc.dashboard.getPeriodComparison.queryOptions({
+          input: dateRangeToApiFormat(dateRange),
+        }),
+      ),
+      context.queryClient.prefetchQuery(
+        orpc.dashboard.getDataQuality.queryOptions({
           input: dateRangeToApiFormat(dateRange),
         }),
       ),
@@ -167,13 +173,21 @@ function RouteComponent() {
     }),
   );
 
+  const { data: dataQuality, isLoading: isDataQualityLoading } = useQuery(
+    orpc.dashboard.getDataQuality.queryOptions({
+      placeholderData: (previousData) => previousData,
+      input: dateRangeToApiFormat(dateRange),
+    }),
+  );
+
   const isLoading =
     isStatsLoading ||
     isCategoryLoading ||
     isMerchantLoading ||
     isTransactionLoading ||
     isSankeyLoading ||
-    isPeriodLoading;
+    isPeriodLoading ||
+    isDataQualityLoading;
 
   return (
     <div className="min-h-full overflow-x-hidden">
@@ -195,6 +209,8 @@ function RouteComponent() {
               })
             }
           />
+
+          <DataQualityCard data={dataQuality} />
 
           <div className="grid grid-cols-1 gap-8 xl:grid-cols-[minmax(0,0.85fr)_minmax(0,1.65fr)] xl:items-start">
             <SectionPanel title="Cash flow overview">


### PR DESCRIPTION
## Summary

Adds a full-width data-quality card to the dashboard that shows reviewed %, unreviewed, and uncategorized transaction counts for the selected period, complementing the existing unreviewed banner.

## Changes

`apps/server/src/routers/dashboard.ts`
- New `getDataQuality` procedure: counts total, reviewed, and uncategorized (`categoryId IS NULL`) transactions within the selected range.

`apps/server/src/routers/index.ts`
- Exports `DashboardDataQuality` type.

`apps/web/src/components/dashboard/data-quality-card.tsx` (new)
- Card with three stats: Reviewed %, Unreviewed (in period), Uncategorized. Hides itself when there are no transactions in the period.

`apps/web/src/routes/dashboard.tsx`
- Prefetches and queries `getDataQuality`, renders the card below the unreviewed banner.

## Verification

- `npm run check-types` passes
- `npx biome check` passes