### PR TITLE
feat(dashboard): show daily average spend and avg transaction size

### DIFF
--- a/apps/server/src/routers/dashboard.ts
+++ b/apps/server/src/routers/dashboard.ts
@@ -153,6 +153,8 @@ async function getStatsForDateRange(
     avgIncomeAmountPerMonth: number;
     avgExpenseAmountPerMonth: number;
     periodLengthInDays: number;
+    avgDailyExpense: number;
+    avgExpensePerTransaction: number;
     avgIncomeForWindow: number | null;
     avgExpenseForWindow: number | null;
     avgTransactionCountForWindow: number | null;
@@ -429,6 +431,22 @@ async function getStatsForDateRange(
     }
   }
 
+  const expenseSum = (() => {
+    if (expenseCount.status !== "fulfilled" || !expenseCount.value[0].amount) {
+      return 0;
+    }
+    return Math.abs(Number(expenseCount.value[0].amount));
+  })();
+  const expenseTxCount =
+    expenseTransactionCount.status === "fulfilled"
+      ? expenseTransactionCount.value[0].count
+      : 0;
+
+  const avgDailyExpense =
+    periodLengthInDays > 0 ? Math.round(expenseSum / periodLengthInDays) : 0;
+  const avgExpensePerTransaction =
+    expenseTxCount > 0 ? Math.round(expenseSum / expenseTxCount) : 0;
+
   return {
     stats: {
       totalTransactions:
@@ -448,6 +466,8 @@ async function getStatsForDateRange(
       avgIncomeAmountPerMonth: avgIncomeAmountPerMonth,
       avgExpenseAmountPerMonth: avgExpenseAmountPerMonth,
       periodLengthInDays,
+      avgDailyExpense,
+      avgExpensePerTransaction,
       avgIncomeForWindow,
       avgExpenseForWindow,
       avgTransactionCountForWindow,

--- a/apps/web/src/components/dashboard/stats.tsx
+++ b/apps/web/src/components/dashboard/stats.tsx
@@ -1,7 +1,9 @@
 import {
+  CalendarDays,
   Minus,
   PiggyBankIcon,
   Plus,
+  Receipt,
   TrendingDownIcon,
   TrendingUpIcon,
 } from "lucide-react";
@@ -116,6 +118,35 @@ export function Stats({ data }: { data: DashboardStats | undefined }) {
             >
               {savingsRate}%
             </span>
+          </div>
+        </div>
+
+        <div className="border-t border-border/60 pt-3 space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <CalendarDays className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">
+                Avg Daily Spend
+              </span>
+            </div>
+            <CurrencyAmount
+              animate
+              amount={Number(data.stats.avgDailyExpense) || 0}
+              className="text-base font-semibold tabular-nums"
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Receipt className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">
+                Avg Expense / Transaction
+              </span>
+            </div>
+            <CurrencyAmount
+              animate
+              amount={Number(data.stats.avgExpensePerTransaction) || 0}
+              className="text-base font-semibold tabular-nums"
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Adds two averages to the dashboard's cash-flow-overview card: average daily spend and average expense per transaction, computed server-side from data already queried by `getStatsCounts` (no new queries or schema changes).

## Changes

`apps/server/src/routers/dashboard.ts`
- `getStatsForDateRange` now also returns `avgDailyExpense` (expenses ÷ period length) and `avgExpensePerTransaction` (expenses ÷ reviewed expense transaction count), rounded to the nearest cent.

`apps/web/src/components/dashboard/stats.tsx`
- Renders the two new averages in a new "Averages" section of the cash-flow-overview card, privacy-aware via `CurrencyAmount`.

## Verification

- `npm run check-types` passes
- `npx biome check` passes