### PR TITLE
fix(dashboard): mask sankey hover tooltip in privacy mode

### DIFF
--- a/apps/web/src/components/dashboard/income-expense-sankey.tsx
+++ b/apps/web/src/components/dashboard/income-expense-sankey.tsx
@@ -557,10 +557,12 @@ export function IncomeExpenseSankey({ data }: { data: DashboardSankeyData }) {
                           ) {
                             percentDenom = data.totalExpenses;
                           }
+                          const amountText = formatCurrency(node.value || 0);
+                          const pctText = `${(((node.value ?? 0) / (percentDenom || 1)) * 100).toFixed(1)}%`;
                           setTooltip({
                             x: rect.left + rect.width / 2,
                             y: rect.top - 10,
-                            content: `${formatCurrency(node.value || 0)} (${(((node.value ?? 0) / (percentDenom || 1)) * 100).toFixed(1)}%)`,
+                            content: `${formatValueWithPrivacy(amountText, isPrivacyMode)} (${formatValueWithPrivacy(pctText, isPrivacyMode)})`,
                           });
                         }}
                         onMouseLeave={() => {


### PR DESCRIPTION
## Summary

Fixes a privacy-mode leak in the income-flow sankey: the node hover tooltip rendered the full amount and percentage via `formatCurrency`, while the node labels themselves were already masked. The tooltip now applies `formatValueWithPrivacy` to both the amount and the percentage.

## Changes

`apps/web/src/components/dashboard/income-expense-sankey.tsx`
- Tooltip content now masks the currency amount and the percentage with `formatValueWithPrivacy` when privacy mode is enabled, matching the node-label masking.

## Verification

- `npm run check-types` passes
- `npx biome check` passes