### PR TITLE
fix(dashboard): click through to exact transaction from largest transactions

### DIFF
--- a/apps/server/src/routers/dashboard.ts
+++ b/apps/server/src/routers/dashboard.ts
@@ -503,7 +503,9 @@ export const dashboardRouter = {
             amount: transaction.amount,
             date: transaction.date,
             transactionDetails: transaction.transactionDetails,
+            notes: transaction.notes,
             merchantName: merchant.name,
+            categoryName: category.name,
           })
           .from(transaction)
           .leftJoin(merchant, eq(transaction.merchantId, merchant.id))

--- a/apps/web/src/components/dashboard/transaction-stats.tsx
+++ b/apps/web/src/components/dashboard/transaction-stats.tsx
@@ -74,7 +74,7 @@ export function TransactionStats({
             navigate({
               to: "/transactions",
               search: {
-                filter: transaction.transactionDetails,
+                filter: transaction.id,
               },
             })
           }
@@ -94,6 +94,10 @@ export function TransactionStats({
                     transaction.merchantName
                       ? transaction.merchantName
                       : "Unknown Merchant"
+                  }${
+                    transaction.categoryName
+                      ? ` • ${transaction.categoryName}`
+                      : ""
                   } • `}
                   {transaction.date ? (
                     <TooltipProvider>
@@ -119,6 +123,11 @@ export function TransactionStats({
                     "Unknown Date"
                   )}
                 </p>
+                {transaction.notes ? (
+                  <p className="text-xs text-muted-foreground truncate max-w-[280px]">
+                    {transaction.notes}
+                  </p>
+                ) : null}
               </div>
             </div>
             <div className="text-right">


### PR DESCRIPTION
## Summary

The Largest Transactions list previously navigated to `/transactions` with a text `filter` on `transactionDetails`, which could match many rows. It now navigates with the transaction `id`, which `getUserTransactions` already matches exactly. The `getTransactionStats` payload is also enriched with `notes` and `categoryName`.

## Changes

`apps/server/src/routers/dashboard.ts`
- `getTransactionStats` now also selects `notes` and `categoryName`.

`apps/web/src/components/dashboard/transaction-stats.tsx`
- Click-through navigates with `filter: transaction.id` (exact match) instead of `filter: transaction.transactionDetails`.
- Each row now shows its category in the subtitle line (when present) and its notes on a separate line (when present).

Note: the transactions page search box will show the transaction id after clicking through — this is what makes the filter exact.

## Verification

- `npm run check-types` passes
- `npx biome check` passes