### PR TITLE
chore(server): drop unused unreviewed count and /6 average fallback

### DIFF
--- a/apps/server/src/routers/dashboard.ts
+++ b/apps/server/src/routers/dashboard.ts
@@ -162,8 +162,6 @@ async function getStatsForDateRange(
     transactionCount,
     expenseCount,
     incomeCount,
-    expenseTransactionCount,
-    incomeTransactionCount,
     avgIncomeAmountsPerMonth,
     avgExpenseAmountsPerMonth,
     avgIncomeTransactionsPerMonth,
@@ -195,34 +193,6 @@ async function getStatsForDateRange(
       ),
     db
       .select({ amount: sum(transaction.amount) })
-      .from(transaction)
-      .innerJoin(category, eq(transaction.categoryId, category.id))
-      .where(
-        and(
-          eq(transaction.userId, userId),
-          eq(category.treatAsIncome, true),
-          eq(category.hideFromInsights, false),
-          eq(transaction.reviewed, true),
-          ...(dateRange.from ? [gte(transaction.date, dateRange.from)] : []),
-          ...(dateRange.to ? [lte(transaction.date, dateRange.to)] : []),
-        ),
-      ),
-    db
-      .select({ count: count() })
-      .from(transaction)
-      .innerJoin(category, eq(transaction.categoryId, category.id))
-      .where(
-        and(
-          eq(transaction.userId, userId),
-          eq(category.treatAsIncome, false),
-          eq(category.hideFromInsights, false),
-          eq(transaction.reviewed, true),
-          ...(dateRange.from ? [gte(transaction.date, dateRange.from)] : []),
-          ...(dateRange.to ? [lte(transaction.date, dateRange.to)] : []),
-        ),
-      ),
-    db
-      .select({ count: count() })
       .from(transaction)
       .innerJoin(category, eq(transaction.categoryId, category.id))
       .where(
@@ -332,12 +302,6 @@ async function getStatsForDateRange(
     );
     avgIncomeAmountPerMonth =
       totalIncomeAmount / avgIncomeAmountsPerMonth.value.length;
-  } else {
-    const totalIncomeAmount =
-      incomeCount.status === "fulfilled" && incomeCount.value[0].amount
-        ? Math.abs(Number(incomeCount.value[0].amount))
-        : 0;
-    if (totalIncomeAmount > 0) avgIncomeAmountPerMonth = totalIncomeAmount / 6;
   }
 
   if (
@@ -350,13 +314,6 @@ async function getStatsForDateRange(
     );
     avgExpenseAmountPerMonth =
       totalExpenseAmount / avgExpenseAmountsPerMonth.value.length;
-  } else {
-    const totalExpenseAmount =
-      expenseCount.status === "fulfilled" && expenseCount.value[0].amount
-        ? Math.abs(Number(expenseCount.value[0].amount))
-        : 0;
-    if (totalExpenseAmount > 0)
-      avgExpenseAmountPerMonth = totalExpenseAmount / 6;
   }
 
   if (
@@ -370,13 +327,6 @@ async function getStatsForDateRange(
     avgIncomeTransactions = Math.round(
       totalIncomeTransactions / avgIncomeTransactionsPerMonth.value.length,
     );
-  } else {
-    const totalIncomeCount =
-      incomeTransactionCount.status === "fulfilled"
-        ? incomeTransactionCount.value[0].count
-        : 0;
-    if (totalIncomeCount > 0)
-      avgIncomeTransactions = Math.round(totalIncomeCount / 6);
   }
 
   if (
@@ -391,13 +341,6 @@ async function getStatsForDateRange(
     avgExpenseTransactions = Math.round(
       totalExpenseTransactions / avgExpenseTransactionsPerMonth.value.length,
     );
-  } else {
-    const totalExpenseCount =
-      expenseTransactionCount.status === "fulfilled"
-        ? expenseTransactionCount.value[0].count
-        : 0;
-    if (totalExpenseCount > 0)
-      avgExpenseTransactions = Math.round(totalExpenseCount / 6);
   }
 
   let periodLengthInDays = 30;

--- a/apps/server/src/routers/meta.ts
+++ b/apps/server/src/routers/meta.ts
@@ -1,5 +1,5 @@
-import { addDays, format } from "date-fns";
-import { and, asc, count, eq, lte } from "drizzle-orm";
+import { format } from "date-fns";
+import { asc, eq } from "drizzle-orm";
 import { db } from "@/db";
 import { account, settings, transaction } from "@/db/schema";
 import { protectedProcedure } from "../lib/orpc";
@@ -106,21 +106,9 @@ export const metaRouter = {
       },
     });
 
-    const unreviewedTransactionCount = await db
-      .select({ count: count() })
-      .from(transaction)
-      .where(
-        and(
-          eq(transaction.userId, context.session?.user?.id),
-          eq(transaction.reviewed, false),
-          lte(transaction.date, format(addDays(new Date(), 30), "yyyy-MM-dd")),
-        ),
-      );
-
     return {
       earliestTransactionDate:
         earliestTransactionDate?.date ?? format(new Date(), "yyyy-MM-dd"),
-      unreviewedTransactionCount: unreviewedTransactionCount[0]?.count ?? 0,
     };
   }),
 };

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -73,7 +73,7 @@ export const useSessionFetch = async () => {
         isPrivacyMode: false,
         webhookUrls: [],
       },
-      meta: { unreviewedTransactionCount: 0, earliestTransactionDate: null },
+      meta: { earliestTransactionDate: null },
       isAuthenticated: true,
     };
   }


### PR DESCRIPTION
## Summary

Two cleanups, stacked on #67 (banner removal, which removes the only consumer of `unreviewedTransactionCount`).

## Changes

`apps/server/src/routers/meta.ts`
- Removes `unreviewedTransactionCount` from `getUserMeta` (its only consumer, the dashboard banner, is removed by #67) along with the now-unused `addDays`, `and`, `count`, `lte` imports.

`apps/web/src/lib/auth-client.ts`
- Drops `unreviewedTransactionCount` from the session fallback default.

`apps/server/src/routers/dashboard.ts`
- Removes the hardcoded `/ 6` fallback branches in `getStatsForDateRange` (which fabricated monthly averages when no historical months existed) and the `incomeTransactionCount`/`expenseTransactionCount` queries that only fed them. Averages are now derived from real monthly history only; the Period-insights card degrades to its "Add more history…" state instead of showing a misleading number.

## Verification

- `npx tsc --noEmit` (web) passes against a clean server build
- `npx biome check` passes on all changed files

> Note: the root `npm run check-types` may fail locally if stale `apps/server/dist` + `apps/web/tsconfig.tsbuildinfo` artifacts are present (project-reference staleness); a clean build resolves it.