### PR TITLE
fix(check-types): clean stale build artifacts before typechecking

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"prepare": "husky",
 		"dev": "turbo dev --filter=web --filter=server",
 		"build": "turbo build --filter=web --filter=server",
-		"check-types": "turbo check-types",
+		"check-types": "rm -rf apps/server/dist apps/web/tsconfig.tsbuildinfo && turbo check-types",
 		"dev:native": "turbo -F native dev",
 		"dev:web": "turbo -F web dev",
 		"dev:server": "turbo -F server dev",


### PR DESCRIPTION
## Summary

Fixes the flaky `npm run check-types` that failed with misleading type errors after switching branches.

## Root cause

The web project resolves the server's types through a TypeScript project reference to `apps/server/dist`, and its own composite build writes `apps/web/tsconfig.tsbuildinfo`. Switching branches leaves these artifacts stale relative to the current source, so `tsc --noEmit` in the web could compile against an outdated server shape (e.g. missing or unexpected procedure fields). Both artifacts are gitignored, so only local dev is affected.

## Change

`package.json`
- `check-types` now clears `apps/server/dist` and `apps/web/tsconfig.tsbuildinfo` before running `turbo check-types`, forcing a deterministic rebuild against current source.

## Verification

- `npm run check-types` passes (server + web) on a fresh run
- Injected a stale `apps/web/tsconfig.tsbuildinfo` and confirmed the script removes it before turbo runs