### PR TITLE
feat(api): add endpoint to create merchants

### DIFF
--- a/apps/server/src/external-api-docs.md
+++ b/apps/server/src/external-api-docs.md
@@ -245,6 +245,50 @@ List all categories for the authenticated user.
 
 ---
 
+## POST /api/merchants
+
+Create a merchant with optional keywords.
+
+### Request Headers
+- `Authorization: Bearer <token>` (required)
+- `Content-Type: application/json`
+
+### Request Body
+```json
+{
+  "name": "Whole Foods",
+  "recommendedCategoryId": "optional-category-uuid",
+  "keywords": ["WHOLEFDS", "WHOLE FOODS"]
+}
+```
+
+- `name` (string, required): Merchant name.
+- `recommendedCategoryId` (string, optional): Category UUID used to auto-categorize transactions matched to this merchant.
+- `keywords` (array of strings, optional): Matching keywords used to auto-assign transactions to this merchant.
+
+### Response
+```json
+{
+  "merchant": {
+    "id": "merchant-uuid",
+    "name": "Whole Foods",
+    "userId": "user-uuid",
+    "recommendedCategoryId": "cat-uuid",
+    "createdAt": "...",
+    "updatedAt": "...",
+    "keywords": [
+      { "id": "kw-uuid", "merchantId": "merchant-uuid", "userId": "user-uuid", "keyword": "WHOLEFDS", ... }
+    ],
+    "recommendedCategory": { "id": "cat-uuid", "name": "Groceries", ... }
+  },
+  "message": "Successfully created merchant"
+}
+```
+
+Returns `409` if a merchant with the same name already exists for the user. Returns `404` if `recommendedCategoryId` does not belong to the user.
+
+---
+
 ## GET /api/merchants
 
 List all merchants for the authenticated user.

--- a/apps/server/src/external-api.ts
+++ b/apps/server/src/external-api.ts
@@ -6,7 +6,7 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
 import { db } from "./db";
-import { category, merchant, transaction } from "./db/schema";
+import { category, merchant, merchantKeyword, transaction } from "./db/schema";
 import { validateAuthToken } from "./lib/auth-token";
 import { logger } from "./lib/logger";
 import {
@@ -579,6 +579,111 @@ externalApi.get("/merchants", async (c) => {
     return c.json({ merchants });
   } catch (error) {
     logger.error("API merchants fetch failed", {
+      error,
+      metadata: {
+        method: c.req.method,
+        url: c.req.url,
+      },
+    });
+    if (error instanceof Error) {
+      return c.json({ error: error.message }, 500);
+    }
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+// POST /merchants - Create a merchant with optional keywords
+externalApi.post("/merchants", async (c) => {
+  try {
+    const userId = await getUserIdFromBearerToken(c);
+    if (!userId) {
+      return c.json(
+        { error: "Missing, invalid, or expired Authorization header" },
+        401,
+      );
+    }
+
+    const body = await c.req.json();
+
+    const createMerchantSchema = z.object({
+      name: z.string().min(1),
+      recommendedCategoryId: z.string().optional(),
+      keywords: z.array(z.string()).optional(),
+    });
+
+    const validationResult = createMerchantSchema.safeParse(body);
+    if (!validationResult.success) {
+      return c.json(
+        {
+          error: "Invalid request format",
+          details: validationResult.error.issues,
+        },
+        400,
+      );
+    }
+
+    const { name, recommendedCategoryId, keywords } = validationResult.data;
+
+    const existingMerchant = await db.query.merchant.findFirst({
+      where: and(eq(merchant.name, name), eq(merchant.userId, userId)),
+    });
+    if (existingMerchant) {
+      return c.json({ error: "A merchant with this name already exists" }, 409);
+    }
+
+    if (recommendedCategoryId) {
+      const categoryRecord = await db.query.category.findFirst({
+        where: and(
+          eq(category.id, recommendedCategoryId),
+          eq(category.userId, userId),
+        ),
+      });
+      if (!categoryRecord) {
+        return c.json({ error: "Recommended category not found" }, 404);
+      }
+    }
+
+    const createdMerchants = await db
+      .insert(merchant)
+      .values({
+        name,
+        userId,
+        recommendedCategoryId,
+      })
+      .returning();
+
+    const createdMerchant = createdMerchants[0];
+
+    if (keywords && keywords.length > 0) {
+      await db.insert(merchantKeyword).values(
+        keywords.map((keyword) => ({
+          merchantId: createdMerchant.id,
+          userId,
+          keyword: keyword.trim(),
+        })),
+      );
+    }
+
+    const merchantWithKeywords = await db.query.merchant.findFirst({
+      where: and(
+        eq(merchant.id, createdMerchant.id),
+        eq(merchant.userId, userId),
+      ),
+      with: {
+        keywords: true,
+        recommendedCategory: true,
+      },
+    });
+
+    return c.json(
+      {
+        merchant: merchantWithKeywords,
+        message: "Successfully created merchant",
+      },
+      201,
+    );
+  } catch (error) {
+    logger.error("API merchant creation failed", {
       error,
       metadata: {
         method: c.req.method,


### PR DESCRIPTION
Adds `POST /api/merchants` to the external REST API, mirroring the existing internal `createMerchant` oRPC procedure.

### Changes
- New `POST /merchants` endpoint in `external-api.ts` accepting `name`, optional `recommendedCategoryId`, and optional `keywords`.
- Returns `201` with the created merchant (including keywords and recommended category).
- Returns `409` when a merchant with the same name already exists for the user, `404` when `recommendedCategoryId` doesn't belong to the user, `401` when the bearer token is missing/invalid, and `400` on invalid request format.
- Documented the new endpoint in `external-api-docs.md`.