### PR TITLE
chore: migrate biome config and fix server env example

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -1,4 +1,11 @@
+# Application origin (must match the web app URL)
 CORS_ORIGIN=http://localhost:3001
-BETTER_AUTH_SECRET=dev-secret-change-in-production-min-32-chars-long
-BETTER_AUTH_URL=http://localhost:3000
+
+# Required Discord OAuth credentials
+DISCORD_CLIENT_ID=
+DISCORD_CLIENT_SECRET=
+
+# Optional: defaults to ${CORS_ORIGIN}/api/auth/callback/discord
+# DISCORD_REDIRECT_URI=http://localhost:3000/api/auth/callback/discord
+
 DATABASE_URL=postgresql://postgres:password@localhost:5432/postgres

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",
@@ -54,7 +54,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "correctness": {
         "useExhaustiveDependencies": "info"
       },


### PR DESCRIPTION
## Summary

Two small DX/config fixes:

1. **Biome config migration** — ran `biome migrate` to bump `biome.json` schema from 2.4.16 to 2.5.7 and replace the deprecated `linter.rules.recommended` with the new `preset` field. This silences schema/deprecation warnings emitted on every `npm run check`.

2. **Fix `apps/server/.env.example`** — the file documented `BETTER_AUTH_*` variables that are no longer used and omitted the two **required** `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET` vars (the server throws at module load without them). Added the required Discord vars and documented the optional `DISCORD_REDIRECT_URI`.

## Verification

- `npx biome check .` runs clean with no config warnings