### PR TITLE
perf(server): match merchants in memory during transaction import

### DIFF
--- a/apps/server/src/external-api.ts
+++ b/apps/server/src/external-api.ts
@@ -76,24 +76,29 @@ externalApi.post("/transactions", async (c) => {
     const { transactions } = validationResult.data;
 
     console.log("Transaction Count:", transactions.length);
-    const { getMerchantFromVendor } = await import("./routers/merchants");
-
-    const transactionData = await Promise.all(
-      transactions.map(async (newTransaction) => {
-        const merchantRecord = await getMerchantFromVendor(
-          newTransaction.transactionDetails,
-          userId,
-        );
-
-        return {
-          ...newTransaction,
-          merchantId: merchantRecord?.id,
-          categoryId: merchantRecord?.recommendedCategoryId,
-          userId: userId,
-          date: new Date(newTransaction.date).toISOString().split("T")[0],
-        };
-      }),
+    const { getUserMerchantsForMatching } = await import("./routers/merchants");
+    const { findBestMatchingMerchant } = await import(
+      "./lib/merchant-matching"
     );
+
+    // Load the user's merchants once and match all transactions in memory
+    // instead of re-querying the full merchant list for each transaction.
+    const userMerchants = await getUserMerchantsForMatching(userId);
+
+    const transactionData = transactions.map((newTransaction) => {
+      const merchantRecord = findBestMatchingMerchant(
+        userMerchants,
+        newTransaction.transactionDetails,
+      );
+
+      return {
+        ...newTransaction,
+        merchantId: merchantRecord?.id,
+        categoryId: merchantRecord?.recommendedCategoryId,
+        userId: userId,
+        date: new Date(newTransaction.date).toISOString().split("T")[0],
+      };
+    });
 
     const insertedTransactions = await db
       .insert(transaction)

--- a/apps/server/src/lib/merchant-matching.ts
+++ b/apps/server/src/lib/merchant-matching.ts
@@ -1,6 +1,7 @@
 export interface MatchableMerchant {
   id: string;
   name: string;
+  recommendedCategoryId?: string | null;
   keywords?: { keyword: string }[];
 }
 

--- a/apps/server/src/routers/merchants.ts
+++ b/apps/server/src/routers/merchants.ts
@@ -9,32 +9,41 @@ import {
 } from "../lib/merchant-matching";
 import { protectedProcedure } from "../lib/orpc";
 
-export async function getMerchantFromVendor(vendor: string, userId: string) {
-  try {
-    // Fetch all merchants with keywords for the user and score them
-    const userMerchants = await db.query.merchant.findMany({
-      where: eq(merchant.userId, userId),
-      with: {
-        keywords: {
-          columns: {
-            keyword: true,
-          },
+/** Fetch a user's merchants (id, name, recommended category, keywords) for
+ *  in-memory keyword matching. Reuse this once per request instead of calling
+ *  getMerchantFromVendor repeatedly (which re-queries all merchants each time).
+ */
+export async function getUserMerchantsForMatching(
+  userId: string,
+): Promise<MatchableMerchant[]> {
+  return db.query.merchant.findMany({
+    where: eq(merchant.userId, userId),
+    columns: {
+      id: true,
+      name: true,
+      recommendedCategoryId: true,
+    },
+    with: {
+      keywords: {
+        columns: {
+          keyword: true,
         },
       },
-    });
+    },
+  });
+}
 
-    const bestMatch = findBestMatchingMerchant(
-      userMerchants as MatchableMerchant[],
-      vendor,
-    );
+export async function getMerchantFromVendor(vendor: string, userId: string) {
+  try {
+    const userMerchants = await getUserMerchantsForMatching(userId);
+
+    const bestMatch = findBestMatchingMerchant(userMerchants, vendor);
 
     return bestMatch
       ? {
           id: bestMatch.id,
           name: bestMatch.name,
-          recommendedCategoryId:
-            (bestMatch as { recommendedCategoryId?: string | null })
-              .recommendedCategoryId ?? null,
+          recommendedCategoryId: bestMatch.recommendedCategoryId ?? null,
         }
       : null;
   } catch (error) {


### PR DESCRIPTION
## Summary

The external API's `POST /transactions` import endpoint called `getMerchantFromVendor` once per transaction (up to 100 times per request), and **each** call re-queried the user's full merchant + keyword list. That's up to 100 full merchant scans per import.

This change:

- Adds `getUserMerchantsForMatching` (`routers/merchants.ts`) which loads the user's merchants **once**, selecting only the columns matching needs (`id`, `name`, `recommendedCategoryId`, keywords).
- Reuses it in `getMerchantFromVendor` and in the import endpoint, which now runs keyword matching **in memory** against all transactions in the request.
- Extends the `MatchableMerchant` type with `recommendedCategoryId`, removing an `as` cast.

Behavior is identical; only the number of DB queries changes (1 vs up to 100).

## Verification

- `npm run check-types` passes
- `npm run check` (Biome) passes