### PR TITLE
style(web): clean up design tokens (radius, shadows, chart palette)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -100,21 +100,6 @@
   --font-sans:
     "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif;
-
-  /* Neutral, low-elevation shadows */
-  --shadow-soft:
-    0 1px 2px rgba(15, 23, 42, 0.04), 0 4px 8px rgba(15, 23, 42, 0.03),
-    0 8px 16px rgba(15, 23, 42, 0.02);
-  --shadow-soft-lg:
-    0 2px 4px rgba(15, 23, 42, 0.04), 0 8px 16px rgba(15, 23, 42, 0.03),
-    0 16px 32px rgba(15, 23, 42, 0.02);
-  --shadow-soft-xl:
-    0 4px 8px rgba(15, 23, 42, 0.04), 0 12px 24px rgba(15, 23, 42, 0.03),
-    0 24px 48px rgba(15, 23, 42, 0.02);
-
-  /* Accent glow effects */
-  --shadow-glow: 0 0 20px rgba(234, 88, 12, 0.18);
-  --shadow-glow-sm: 0 0 12px rgba(234, 88, 12, 0.1);
 }
 
 html,
@@ -133,15 +118,17 @@ body {
    ========================================== */
 
 :root {
-  /* A compact, consistent radius scale */
+  /* Radius scale — kept in sync with the @theme inline tokens that back
+     the rounded-* utilities; these vars also serve var(--radius-*) refs
+     such as the global :focus-visible rule. */
   --radius: 0.75rem;
-  --radius-sm: 0.5rem;
-  --radius-md: 0.75rem;
-  --radius-lg: 1rem;
-  --radius-xl: 1.25rem;
+  --radius-sm: 0.375rem;
+  --radius-md: 0.625rem;
+  --radius-lg: 0.875rem;
+  --radius-xl: 1.125rem;
   --radius-2xl: 1.5rem;
 
-  /* Shadows */
+  /* Light-mode shadows. Overridden for dark mode in .dark below. */
   --shadow-soft:
     0 1px 2px rgba(15, 23, 42, 0.04), 0 4px 8px rgba(15, 23, 42, 0.03),
     0 8px 16px rgba(15, 23, 42, 0.02);
@@ -219,6 +206,8 @@ body {
 
   /* ==========================================
      CHART COLORS - Vibrant Palette
+     Hue-aligned with the dark palette (orange, teal, slate, rose, sky,
+     lime, amber, violet) so categories keep their color across themes.
      ========================================== */
   --chart-1: #ea580c;
   --chart-2: #0f766e;
@@ -227,7 +216,7 @@ body {
   --chart-5: #0369a1;
   --chart-6: #4d7c0f;
   --chart-7: #a16207;
-  --chart-8: #334155;
+  --chart-8: #6d28d9;
 
   /* ==========================================
      SIDEBAR
@@ -274,7 +263,9 @@ body {
   /* ==========================================
      MUTED - Warm Dark Gray
      ========================================== */
-  --muted: #27272a;
+  /* Intentionally distinct from --secondary (which doubles as interactive
+     hover surfaces); muted reads as a slightly recessed backdrop. */
+  --muted: #1f1f23;
   --muted-foreground: #a1a1aa;
 
   /* ==========================================
@@ -307,16 +298,18 @@ body {
   --savings-muted: #0f766e;
 
   /* ==========================================
-     CHART COLORS - Dark Mode (vibrant)
+     CHART COLORS - Dark Mode
+     Hue-aligned with the light palette so a category keeps its color family
+     across themes; every entry is visually distinct.
      ========================================== */
-  --chart-1: #fb923c;
-  --chart-2: #2dd4bf;
-  --chart-3: #fbbf24;
-  --chart-4: #fbbf24;
-  --chart-5: #22d3ee;
-  --chart-6: #a3e635;
-  --chart-7: #fb7185;
-  --chart-8: #fdba74;
+  --chart-1: #fb923c; /* orange */
+  --chart-2: #2dd4bf; /* teal */
+  --chart-3: #94a3b8; /* slate */
+  --chart-4: #fb7185; /* rose */
+  --chart-5: #38bdf8; /* sky */
+  --chart-6: #a3e635; /* lime */
+  --chart-7: #fbbf24; /* amber */
+  --chart-8: #c084fc; /* violet */
 
   /* ==========================================
      SIDEBAR


### PR DESCRIPTION
## Group 1 — Design tokens

Part of a styling-consistency audit. This PR consolidates the conflicting design tokens in `apps/web/src/index.css`.

### Where to see the changes

All changes are in **`apps/web/src/index.css`**.

**1. Radius scale — two conflicting scales collapsed to one**
- The `:root` block declared `--radius-sm/md/lg/xl/2xl` as `0.5/0.75/1/1.25/1.5rem`, while `@theme inline` (which actually backs the `rounded-*` utilities) declared `0.375/0.625/0.875/1.125/1.5rem`.
- `:root` is now aligned with `@theme inline`, so `var(--radius-*)` references (e.g. the global `:focus-visible { border-radius: var(--radius-md) }`) match what the utilities render.

**2. Shadows — triple definition reduced to two**
- Shadows were declared in three places with slightly differing values (top `@theme`, `:root`, and `.dark`).
- The top-level `@theme` duplicate is removed. `:root` (light) and `.dark` are now the single source of truth; `@theme inline` still re-exports the tokens for the `shadow-soft*`/`shadow-glow*` utilities. Verified the compiled CSS still emits correct light and dark values.

**3. Dark chart palette — duplicate + near-duplicate colors fixed**
- `--chart-3` and `--chart-4` were both `#fbbf24`, and `--chart-8` (`#fdba74`) was nearly identical to `--chart-1` (`#fb923c`).
- Dark palette is now hue-aligned with light (orange, teal, slate, rose, sky, lime, amber, violet) so a category keeps its color family across themes. Also replaced light `--chart-8` (`#334155`, a second slate alongside `chart-3`) with violet `#6d28d9`.

**4. Dark `--muted` vs `--secondary` no longer identical**
- Both were `#27272a` in dark mode. `--muted` is now `#1f1f23` (a slightly recessed backdrop) while `--secondary` remains the interactive hover surface.