### PR TITLE
style(web): consolidate color semantics (accent/primary, hardcoded colors)

### DIFF
--- a/apps/web/src/components/dashboard/category-pie-chart.tsx
+++ b/apps/web/src/components/dashboard/category-pie-chart.tsx
@@ -5,39 +5,12 @@ import { ChevronDown } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { CurrencyAmount } from "@/components/ui/currency-amount";
+import { getColorFromCategoryId } from "@/lib/chart-colors";
 import type {
   DashboardCategoryData,
   DashboardPeriodComparison,
 } from "../../../../server/src/routers";
 import { formatCategoryText } from "../categories/category-select";
-
-const chartColors = [
-  "var(--chart-1)",
-  "var(--chart-2)",
-  "var(--chart-3)",
-  "var(--chart-4)",
-  "var(--chart-5)",
-  "var(--chart-6)",
-  "var(--chart-7)",
-  "var(--chart-8)",
-  "#f59e0b", // amber
-  "#84cc16", // lime
-  "#06b6d4", // cyan
-  "#ea580c", // orange
-];
-
-function hashString(str: string): number {
-  let hash = 5381;
-  for (let i = 0; i < str.length; i++) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  return hash >>> 0;
-}
-
-function getColorFromCategoryId(categoryId: string): string {
-  const hash = hashString(categoryId);
-  return chartColors[hash % chartColors.length];
-}
 
 interface ChartItem {
   id: string;

--- a/apps/web/src/components/dashboard/income-expense-sankey.tsx
+++ b/apps/web/src/components/dashboard/income-expense-sankey.tsx
@@ -10,40 +10,13 @@ import { useMemo, useRef, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { CurrencyAmount } from "@/components/ui/currency-amount";
 import { useSession } from "@/lib/auth-client";
+import { getColorFromCategoryId } from "@/lib/chart-colors";
 import { formatCurrency, formatValueWithPrivacy } from "@/lib/utils";
 import type { DashboardSankeyData } from "../../../../server/src/routers";
 
-const INCOME_COLOR = "#22c55e";
-const SAVED_COLOR = "#3b82f6";
-const EXPENSES_NODE_COLOR = "#ef4444";
-
-const chartColors = [
-  "var(--chart-1)",
-  "var(--chart-2)",
-  "var(--chart-3)",
-  "var(--chart-4)",
-  "var(--chart-5)",
-  "var(--chart-6)",
-  "var(--chart-7)",
-  "var(--chart-8)",
-  "#f59e0b",
-  "#84cc16",
-  "#06b6d4",
-  "#ea580c",
-];
-
-function hashString(str: string): number {
-  let hash = 5381;
-  for (let i = 0; i < str.length; i++) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
-  }
-  return hash >>> 0;
-}
-
-function getColorFromCategoryId(categoryId: string): string {
-  const hash = hashString(categoryId);
-  return chartColors[hash % chartColors.length];
-}
+const INCOME_COLOR = "var(--income)";
+const SAVED_COLOR = "var(--savings)";
+const EXPENSES_NODE_COLOR = "var(--expense)";
 
 interface SankeyNode {
   id: string;
@@ -221,7 +194,7 @@ export function IncomeExpenseSankey({ data }: { data: DashboardSankeyData }) {
         source: "expenses",
         target: parentNodeId,
         value: parent.amount,
-        color: "#ef4444",
+        color: EXPENSES_NODE_COLOR,
       });
     }
 

--- a/apps/web/src/components/dashboard/stats.tsx
+++ b/apps/web/src/components/dashboard/stats.tsx
@@ -114,7 +114,7 @@ export function Stats({ data }: { data: DashboardStats | undefined }) {
               </span>
             </div>
             <span
-              className={`text-base font-semibold tabular-nums ${savingsRate >= 20 ? "text-savings" : savingsRate >= 10 ? "text-amber-500" : "text-muted-foreground"}`}
+              className={`text-base font-semibold tabular-nums ${savingsRate >= 20 ? "text-savings" : savingsRate >= 10 ? "text-warning" : "text-muted-foreground"}`}
             >
               {savingsRate}%
             </span>

--- a/apps/web/src/components/layout/top-nav.tsx
+++ b/apps/web/src/components/layout/top-nav.tsx
@@ -101,12 +101,12 @@ export function TopNav({ onMenuClick }: TopNavProps) {
                 className={cn(
                   "flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg transition-colors",
                   isActive
-                    ? "text-primary bg-primary/10"
+                    ? "text-accent bg-accent/10"
                     : "text-muted-foreground hover:text-foreground hover:bg-secondary",
                 )}
               >
                 <item.icon
-                  className={cn("w-4 h-4", isActive && "text-primary")}
+                  className={cn("w-4 h-4", isActive && "text-accent")}
                 />
                 <span>{item.label}</span>
               </Link>

--- a/apps/web/src/components/transactions/split-transaction-dialog.tsx
+++ b/apps/web/src/components/transactions/split-transaction-dialog.tsx
@@ -303,11 +303,7 @@ export function SplitTransactionDialog({
           >
             Cancel
           </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={!isValid || isPending}
-            className="bg-accent hover:bg-accent/90 text-accent-foreground"
-          >
+          <Button onClick={handleSubmit} disabled={!isValid || isPending}>
             {isPending ? "Splitting..." : "Split Transaction"}
           </Button>
         </DialogFooter>

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -20,7 +20,7 @@ const badgeVariants = cva(
         success:
           "border-income/20 bg-income/10 text-income [a&]:hover:bg-income/20 [a&]:hover:border-income/30",
         warning:
-          "border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-400 [a&]:hover:bg-amber-500/20",
+          "border-warning/20 bg-warning/10 text-warning [a&]:hover:bg-warning/20 [a&]:hover:border-warning/30",
       },
     },
     defaultVariants: {

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground border-transparent shadow-[0_1px_2px_rgba(194,65,12,0.2),0_2px_4px_rgba(194,65,12,0.12)] hover:bg-primary/90 hover:shadow-[0_2px_4px_rgba(194,65,12,0.22),0_4px_8px_rgba(194,65,12,0.14)] hover:-translate-y-px",
+          "bg-accent text-accent-foreground border-transparent shadow-[0_1px_2px_rgba(234,88,12,0.2),0_2px_4px_rgba(234,88,12,0.12)] hover:bg-accent/90 hover:shadow-[0_2px_4px_rgba(234,88,12,0.22),0_4px_8px_rgba(234,88,12,0.14)] hover:-translate-y-px",
         destructive:
           "bg-destructive text-destructive-foreground border-transparent shadow-[0_1px_2px_rgba(220,38,38,0.15),0_2px_4px_rgba(220,38,38,0.1)] hover:shadow-[0_2px_4px_rgba(220,38,38,0.2),0_4px_8px_rgba(220,38,38,0.15)] hover:-translate-y-[1px]",
         outline:

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -216,6 +216,8 @@ body {
   --expense-muted: #fee2e2;
   --savings: #0d9488;
   --savings-muted: #ccfbf1;
+  --warning: #d97706;
+  --warning-muted: #fef3c7;
 
   /* ==========================================
      CHART COLORS - Vibrant Palette
@@ -305,6 +307,8 @@ body {
   --expense-muted: #450a0a;
   --savings: #2dd4bf;
   --savings-muted: #0f766e;
+  --warning: #fbbf24;
+  --warning-muted: #78350f;
 
   /* ==========================================
      CHART COLORS - Dark Mode (vibrant)
@@ -398,6 +402,8 @@ body {
   --color-income-muted: var(--income-muted);
   --color-expense-muted: var(--expense-muted);
   --color-savings-muted: var(--savings-muted);
+  --color-warning: var(--warning);
+  --color-warning-muted: var(--warning-muted);
 }
 
 @layer base {

--- a/apps/web/src/lib/chart-colors.ts
+++ b/apps/web/src/lib/chart-colors.ts
@@ -1,0 +1,30 @@
+// Shared categorical chart palette. The first eight entries reference the
+// theme's --chart-* tokens so colors adapt to light/dark mode; the extras
+// cover large category sets beyond eight.
+export const chartColors = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
+  "var(--chart-7)",
+  "var(--chart-8)",
+  "#f59e0b", // amber
+  "#84cc16", // lime
+  "#06b6d4", // cyan
+  "#ea580c", // orange
+];
+
+function hashString(str: string): number {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 33) ^ str.charCodeAt(i);
+  }
+  return hash >>> 0;
+}
+
+export function getColorFromCategoryId(categoryId: string): string {
+  const hash = hashString(categoryId);
+  return chartColors[hash % chartColors.length];
+}

--- a/apps/web/src/routes/categories.tsx
+++ b/apps/web/src/routes/categories.tsx
@@ -116,7 +116,7 @@ function RouteComponent() {
         actions={
           <Dialog open={open} onOpenChange={setOpen}>
             <DialogTrigger asChild>
-              <Button className="bg-accent hover:bg-accent/90 text-accent-foreground font-medium">
+              <Button>
                 <Plus className="w-4 h-4 mr-2" />
                 New category
               </Button>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -116,11 +116,7 @@ function HomeComponent() {
               decisions with clear insights.
             </p>
             <div className="flex flex-col sm:flex-row gap-3 justify-center">
-              <Button
-                asChild
-                size="lg"
-                className="bg-accent hover:bg-accent/90 text-accent-foreground font-medium"
-              >
+              <Button asChild size="lg">
                 <Link to="/signin">Get started free</Link>
               </Button>
             </div>
@@ -173,11 +169,7 @@ function HomeComponent() {
           <p className="text-muted-foreground mb-6 max-w-md mx-auto">
             Connect your data or add transactions manually—you’re in control.
           </p>
-          <Button
-            asChild
-            size="lg"
-            className="bg-accent hover:bg-accent/90 text-accent-foreground font-medium"
-          >
+          <Button asChild size="lg">
             <Link to="/signin">Get started free</Link>
           </Button>
         </div>

--- a/apps/web/src/routes/merchants.tsx
+++ b/apps/web/src/routes/merchants.tsx
@@ -141,7 +141,7 @@ function RouteComponent() {
             </AlertDialog>
             <Dialog open={open} onOpenChange={setOpen}>
               <DialogTrigger asChild>
-                <Button className="bg-accent hover:bg-accent/90 text-accent-foreground font-medium">
+                <Button>
                   <Plus className="w-4 h-4 mr-2" />
                   New merchant
                 </Button>

--- a/apps/web/src/routes/transactions.tsx
+++ b/apps/web/src/routes/transactions.tsx
@@ -451,7 +451,7 @@ function RouteComponent() {
               }}
             >
               <DialogTrigger asChild>
-                <Button className="bg-accent hover:bg-accent/90 text-accent-foreground font-medium">
+                <Button>
                   <Plus className="w-4 h-4 mr-2" />
                   Add transaction
                 </Button>


### PR DESCRIPTION
## Group 3 — Color semantics

Part of a styling-consistency audit. The app mixed three oranges (`--primary`, `--accent`, `--ring`) for the same "primary action" role, and several components hardcoded colors that drifted from the theme tokens.

### Where to see the changes

**`apps/web/src/components/ui/button.tsx`** — the default variant now uses `bg-accent` (the vivid orange that every primary CTA was already overriding to) instead of `bg-primary`; its hover shadow tones were updated to the accent hue.

**`apps/web/src/routes/transactions.tsx`, `routes/merchants.tsx`, `routes/categories.tsx`, `routes/index.tsx` (landing CTAs), and `components/transactions/split-transaction-dialog.tsx`** — removed the now-redundant `bg-accent hover:bg-accent/90 text-accent-foreground font-medium` overrides on primary buttons. `primary` is still used where it belongs (links, switches, the unreviewed banner).

**`apps/web/src/components/layout/top-nav.tsx`** — the active nav item was `text-primary bg-primary/10` while the mobile drawer used `text-accent bg-accent/10`; top-nav now uses `accent` so both surfaces agree.

**`apps/web/src/index.css`** — added `--warning` / `--warning-muted` tokens for both themes and registered them via `@theme inline`.

**`apps/web/src/components/ui/badge.tsx`** — the `warning` variant now uses the warning tokens instead of hardcoded `amber-*` classes.

**`apps/web/src/components/dashboard/stats.tsx`** — the savings-rate warning color is now `text-warning`.

**`apps/web/src/lib/chart-colors.ts`** *(new)* — shared categorical chart palette + `getColorFromCategoryId`, replacing the duplicated 12-color arrays/hashing in **`components/dashboard/category-pie-chart.tsx`** and **`components/dashboard/income-expense-sankey.tsx`**.

**`apps/web/src/components/dashboard/income-expense-sankey.tsx`** — income/saved/expense node & link colors now reference `var(--income)` / `var(--savings)` / `var(--expense)` instead of hardcoded `#22c55e` / `#3b82f6` / `#ef4444`, so they stay in sync with `CurrencyAmount` and dark mode.

> Note: this branch also touches `index.css`, which PR #81 (design tokens) touches. If both are open simultaneously there may be a small merge conflict on merge; it resolves trivially.