### PR TITLE
style(web): standardize card surface borders, shadows, and padding

### DIFF
--- a/apps/web/src/components/categories/category-card.tsx
+++ b/apps/web/src/components/categories/category-card.tsx
@@ -56,7 +56,7 @@ export function CategoryCard({
     : FolderIcon;
 
   return (
-    <div className="rounded-xl border border-border/80 bg-card shadow-sm p-4">
+    <div className="rounded-xl border border-border bg-card shadow-soft p-4 sm:p-5">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Icon

--- a/apps/web/src/components/categories/category-list.tsx
+++ b/apps/web/src/components/categories/category-list.tsx
@@ -60,7 +60,7 @@ export function CategoryList({
         .map((orphanedChild) => (
           <div
             key={orphanedChild.id}
-            className="rounded-xl border border-border/80 bg-card shadow-sm p-4"
+            className="rounded-xl border border-border bg-card shadow-soft p-4 sm:p-5"
           >
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">

--- a/apps/web/src/components/dashboard/category-pie-chart.tsx
+++ b/apps/web/src/components/dashboard/category-pie-chart.tsx
@@ -174,7 +174,7 @@ export function CategoryPieChart({
 
   if (!data || data.length === 0) {
     return (
-      <Card className="shadow-sm">
+      <Card>
         <CardContent className="p-6">
           <div className="flex flex-col items-center justify-center py-8 text-center">
             <p className="text-muted-foreground text-sm">
@@ -187,7 +187,7 @@ export function CategoryPieChart({
   }
 
   return (
-    <Card className="shadow-sm">
+    <Card>
       <CardContent className="p-4">
         <div className="flex flex-col sm:flex-row gap-4">
           {/* Chart Section */}

--- a/apps/web/src/components/dashboard/income-expense-sankey.tsx
+++ b/apps/web/src/components/dashboard/income-expense-sankey.tsx
@@ -375,7 +375,7 @@ export function IncomeExpenseSankey({ data }: { data: DashboardSankeyData }) {
 
   if (!data || data.totalIncome === 0) {
     return (
-      <Card className="shadow-sm">
+      <Card>
         <CardContent className="p-6">
           <div className="flex flex-col items-center justify-center py-8 text-center">
             <p className="text-muted-foreground text-sm">
@@ -389,7 +389,7 @@ export function IncomeExpenseSankey({ data }: { data: DashboardSankeyData }) {
 
   if (nodes.length === 0 || links.length === 0) {
     return (
-      <Card className="shadow-sm">
+      <Card>
         <CardContent className="p-6">
           <div className="flex flex-col items-center justify-center py-8 text-center">
             <p className="text-muted-foreground text-sm">
@@ -402,7 +402,7 @@ export function IncomeExpenseSankey({ data }: { data: DashboardSankeyData }) {
   }
 
   return (
-    <Card className="shadow-sm w-full">
+    <Card className="w-full">
       <CardContent className="p-2 md:p-4">
         <div className="w-full overflow-x-auto">
           <div className="min-w-[400px] w-full md:min-w-[550px]">

--- a/apps/web/src/components/dashboard/merchant-stats.tsx
+++ b/apps/web/src/components/dashboard/merchant-stats.tsx
@@ -50,7 +50,7 @@ export function MerchantStats({
         return (
           <Card
             key={merchant.merchantId}
-            className="px-3 py-2 sm:px-4 sm:py-3 shadow-sm cursor-pointer hover:bg-muted/50 transition-colors"
+            className="px-3 py-2 sm:px-4 sm:py-3 cursor-pointer hover:bg-muted/50 transition-colors"
             onClick={() => handleMerchantClick(merchant.merchantId)}
             aria-label={`View transactions for ${merchant.merchantName}`}
           >

--- a/apps/web/src/components/dashboard/period-insights.tsx
+++ b/apps/web/src/components/dashboard/period-insights.tsx
@@ -195,7 +195,7 @@ export function PeriodInsights({
   }
 
   return (
-    <Card className="border-border/80 bg-card/90 p-4 sm:p-5 shadow-sm">
+    <Card className="border-border bg-card p-4 sm:p-5">
       <div className="mb-3">
         <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
           {usePrevious ? "Vs previous period" : "Vs your average"}

--- a/apps/web/src/components/dashboard/stats.tsx
+++ b/apps/web/src/components/dashboard/stats.tsx
@@ -40,7 +40,7 @@ export function Stats({ data }: { data: DashboardStats | undefined }) {
   })();
 
   return (
-    <Card className="border-border/80 bg-card/90 p-4 sm:p-5">
+    <Card className="border-border bg-card p-4 sm:p-5">
       <div className="space-y-4">
         <div>
           <p className="text-xs font-semibold tracking-wider uppercase text-muted-foreground">

--- a/apps/web/src/components/dashboard/transaction-stats.tsx
+++ b/apps/web/src/components/dashboard/transaction-stats.tsx
@@ -69,7 +69,7 @@ export function TransactionStats({
       {data.map((transaction) => (
         <Card
           key={transaction.id}
-          className="px-3 py-2 sm:px-4 sm:py-3 shadow-sm cursor-pointer hover:bg-muted/50 transition-colors"
+          className="px-3 py-2 sm:px-4 sm:py-3 cursor-pointer hover:bg-muted/50 transition-colors"
           onClick={() =>
             navigate({
               to: "/transactions",

--- a/apps/web/src/components/merchants/merchant-card.tsx
+++ b/apps/web/src/components/merchants/merchant-card.tsx
@@ -60,7 +60,7 @@ export function MerchantCard({ merchant, onDelete }: MerchantCardProps) {
   };
 
   return (
-    <div className="rounded-xl border border-border/80 bg-card shadow-sm p-4">
+    <div className="rounded-xl border border-border bg-card shadow-soft p-4 sm:p-5">
       <div className="flex items-start justify-between gap-3">
         <div className="flex-1 min-w-0 pr-2">
           <div className="flex items-center gap-2 mb-1">

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -142,10 +142,7 @@ function HomeComponent() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {features.map((feature) => (
-            <Card
-              key={feature.title}
-              className="group border-border/80 bg-card shadow-sm hover:shadow-md transition-shadow"
-            >
+            <Card key={feature.title} className="group border-border">
               <CardHeader>
                 <div className="w-10 h-10 rounded-lg bg-muted flex items-center justify-center mb-3 text-muted-foreground">
                   {feature.icon}

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -207,7 +207,7 @@ function RouteComponent() {
                 share it publicly.
               </p>
             </div>
-            <div className="rounded-xl border border-border/80 bg-card shadow-sm p-4">
+            <div className="rounded-xl border border-border bg-card shadow-soft p-4 sm:p-5">
               <div className="flex flex-col sm:flex-row gap-3 items-stretch sm:items-end mb-3">
                 <div className="relative flex-1">
                   <Input
@@ -280,7 +280,7 @@ function RouteComponent() {
                 transactions are imported.
               </p>
             </div>
-            <div className="rounded-xl border border-border/80 bg-card shadow-sm p-4">
+            <div className="rounded-xl border border-border bg-card shadow-soft p-4 sm:p-5">
               <div className="flex flex-col sm:flex-row gap-3 items-stretch sm:items-end mb-4">
                 <div className="relative flex-1">
                   <Input
@@ -397,7 +397,7 @@ function RouteComponent() {
                 Enable additional developer tools and debugging options.
               </p>
             </div>
-            <div className="rounded-xl border border-border/80 bg-card shadow-sm p-4">
+            <div className="rounded-xl border border-border bg-card shadow-soft p-4 sm:p-5">
               <div className="flex items-center justify-between py-1">
                 <Label
                   htmlFor={devModeId}
@@ -429,7 +429,7 @@ function RouteComponent() {
                 Hide sensitive information and transaction details from view.
               </p>
             </div>
-            <div className="rounded-xl border border-border/80 bg-card shadow-sm p-4">
+            <div className="rounded-xl border border-border bg-card shadow-soft p-4 sm:p-5">
               <div className="flex items-center justify-between py-1">
                 <Label
                   htmlFor={privacyModeId}


### PR DESCRIPTION
## Group 4 — Card surfaces

Part of a styling-consistency audit. The same "card" concept used different border weights (`border-border` vs `border-border/80`), different shadows (`shadow-sm` vs `shadow-soft`), and different padding (`p-4`, `p-4 sm:p-5`) depending on which file built it.

The shared spec is now the `Card` primitive: `rounded-xl` + `border-border` + `shadow-soft`, with compact content cards using `p-4 sm:p-5`.

### Where to see the changes

- **`components/merchants/merchant-card.tsx`** — card `border-border/80` + `shadow-sm` → `border-border` + `shadow-soft`; padding `p-4` → `p-4 sm:p-5`.
- **`components/categories/category-card.tsx`** — same treatment.
- **`components/categories/category-list.tsx`** — orphaned-category row same treatment.
- **`routes/settings.tsx`** — all four settings tiles (`API Token`, `Auto-Import Webhook URLs`, `Developer Mode`, `Privacy Mode`) same treatment.
- **`components/dashboard/stats.tsx`** — `border-border/80 bg-card/90` → `border-border bg-card` (primitive shadow now applies).
- **`components/dashboard/period-insights.tsx`** — dropped the `border-border/80 bg-card/90 shadow-sm` overrides (primitive defaults now apply); the two dashed placeholder cards are intentionally left as-is.
- **`components/dashboard/merchant-stats.tsx`** / **`transaction-stats.tsx`** — removed `shadow-sm` overrides on list rows so they use the primitive's `shadow-soft`.
- **`routes/index.tsx`** — landing feature cards dropped `border-border/80 shadow-sm hover:shadow-md`; they now use the primitive's `border-border` + `shadow-soft` + `hover:shadow-soft-lg`.
- **`components/dashboard/category-pie-chart.tsx`** and **`components/dashboard/income-expense-sankey.tsx`** — removed `shadow-sm` overrides.