### PR TITLE
style(web): extract a shared EmptyState component

### DIFF
--- a/apps/web/src/components/categories/category-list.tsx
+++ b/apps/web/src/components/categories/category-list.tsx
@@ -1,5 +1,6 @@
 import { FolderIcon, XIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
 import type { Category } from "../../../../server/src/routers";
 import { CategoryCard } from "./category-card";
 
@@ -24,13 +25,12 @@ export function CategoryList({
 
   if (!categories.length) {
     return (
-      <div className="flex flex-col items-center justify-center p-8 text-center rounded-xl border border-border/80 bg-card shadow-sm">
-        <FolderIcon className="mb-3 h-12 w-12 text-muted-foreground" />
-        <h3 className="mb-2 text-lg font-semibold">No categories yet</h3>
-        <p className="text-sm text-muted-foreground">
-          Create your first category to get started
-        </p>
-      </div>
+      <EmptyState
+        icon={<FolderIcon className="h-12 w-12 text-muted-foreground" />}
+        title="No categories yet"
+        description="Create your first category to get started"
+        bordered={false}
+      />
     );
   }
 

--- a/apps/web/src/components/dashboard/stats.tsx
+++ b/apps/web/src/components/dashboard/stats.tsx
@@ -8,6 +8,7 @@ import {
   TrendingUpIcon,
 } from "lucide-react";
 import { Card } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
 import type { DashboardStats } from "../../../../server/src/routers";
 
 import { CurrencyAmount } from "../ui/currency-amount";
@@ -15,16 +16,12 @@ import { CurrencyAmount } from "../ui/currency-amount";
 export function Stats({ data }: { data: DashboardStats | undefined }) {
   if (!data) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <div className="rounded-2xl bg-secondary p-5 mb-4 shadow-sm">
-          <TrendingUpIcon className="h-10 w-10 text-muted-foreground" />
-        </div>
-        <h3 className="text-lg font-semibold mb-2">No Data Available</h3>
-        <p className="text-sm text-muted-foreground max-w-sm">
-          Your dashboard statistics will appear here once you start adding
-          transactions.
-        </p>
-      </div>
+      <EmptyState
+        icon={<TrendingUpIcon className="h-10 w-10 text-muted-foreground" />}
+        title="No Data Available"
+        description="Your dashboard statistics will appear here once you start adding transactions."
+        bordered={false}
+      />
     );
   }
 

--- a/apps/web/src/components/merchants/merchant-list.tsx
+++ b/apps/web/src/components/merchants/merchant-list.tsx
@@ -1,4 +1,5 @@
 import { StoreIcon } from "lucide-react";
+import { EmptyState } from "@/components/ui/empty-state";
 import type { MerchantWithKeywordsAndCategory } from "../../../../server/src/routers";
 import { MerchantCard } from "./merchant-card";
 
@@ -23,13 +24,12 @@ export function MerchantList({
 
   if (!merchants.length) {
     return (
-      <div className="flex flex-col items-center justify-center p-8 text-center rounded-xl border border-border/80 bg-card shadow-sm">
-        <StoreIcon className="mb-3 h-12 w-12 text-muted-foreground" />
-        <h3 className="mb-2 text-lg font-semibold">No merchants yet</h3>
-        <p className="text-sm text-muted-foreground">
-          Add your first merchant to get started
-        </p>
-      </div>
+      <EmptyState
+        icon={<StoreIcon className="h-12 w-12 text-muted-foreground" />}
+        title="No merchants yet"
+        description="Add your first merchant to get started"
+        bordered={false}
+      />
     );
   }
 

--- a/apps/web/src/components/ui/card-list.tsx
+++ b/apps/web/src/components/ui/card-list.tsx
@@ -1,5 +1,6 @@
 import { type ComponentProps } from "react";
 import { cn } from "@/lib/utils";
+import { EmptyState } from "@/components/ui/empty-state";
 
 function CardListItem({
   className,
@@ -29,25 +30,20 @@ function CardListEmpty({
   icon,
   title,
   description,
-  ...props
-}: ComponentProps<"div"> & {
+}: {
+  className?: string;
   icon: React.ReactNode;
   title: string;
   description: string;
 }) {
   return (
-    <div
-      data-slot="card-list-empty"
-      className={cn(
-        "flex flex-col items-center justify-center py-16 text-center",
-        className
-      )}
-      {...props}
-    >
-      <div className="rounded-full bg-muted p-4 mb-4">{icon}</div>
-      <h3 className="text-lg font-semibold mb-2">{title}</h3>
-      <p className="text-sm text-muted-foreground max-w-sm">{description}</p>
-    </div>
+    <EmptyState
+      icon={icon}
+      title={title}
+      description={description}
+      bordered={false}
+      className={className}
+    />
   );
 }
 

--- a/apps/web/src/components/ui/empty-state.tsx
+++ b/apps/web/src/components/ui/empty-state.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+
+interface EmptyStateProps {
+	icon?: ReactNode
+	title: string
+	description?: ReactNode
+	className?: string
+	/** Compact vertical padding (py-8 instead of py-16) */
+	compact?: boolean
+	/** Wrap in a bordered card surface (default true) */
+	bordered?: boolean
+}
+
+function EmptyState({
+	icon,
+	title,
+	description,
+	className,
+	compact = false,
+	bordered = true,
+}: EmptyStateProps) {
+	return (
+		<div
+			className={cn(
+				"flex flex-col items-center justify-center text-center",
+				compact ? "py-8" : "py-16",
+				bordered && "rounded-xl border border-border bg-card shadow-soft px-6",
+				className,
+			)}
+		>
+			{icon && (
+				<div className="mb-4 flex items-center justify-center rounded-full bg-muted p-4">
+					{icon}
+				</div>
+			)}
+			<h3 className="mb-2 text-lg font-semibold">{title}</h3>
+			{description && (
+				<p className="max-w-sm text-sm leading-relaxed text-muted-foreground">
+					{description}
+				</p>
+			)}
+		</div>
+	)
+}
+
+export { EmptyState }

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -5,7 +5,7 @@ import {
   useSearch,
 } from "@tanstack/react-router";
 import { format, parseISO, startOfMonth } from "date-fns";
-import { Plus } from "lucide-react";
+import { CreditCardIcon, Plus, StoreIcon } from "lucide-react";
 import { type ReactNode, useMemo } from "react";
 import type { DateRange } from "react-day-picker";
 import { z } from "zod";
@@ -20,6 +20,7 @@ import DateRangePicker from "@/components/date-picker/date-range-picker";
 import { DelayedLoading } from "@/components/delayed-loading";
 import { PageHeader } from "@/components/layout/page-header";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
 import { ensureSession, useSession } from "@/lib/auth-client";
 import { dateRangeToApiFormat } from "@/lib/utils";
 import { orpc } from "@/utils/orpc";
@@ -318,9 +319,12 @@ function DashboardCharts({
       {categoryData && categoryData.length > 0 ? (
         <CategoryPieChart data={categoryData} previous={previousCategories} />
       ) : (
-        <div className="min-h-[250px] sm:min-h-[300px] flex items-center justify-center text-muted-foreground text-sm rounded-xl bg-muted/40">
-          No category data
-        </div>
+        <EmptyState
+          compact
+          bordered={false}
+          title="No category data"
+          description="Add transactions to see a spending breakdown."
+        />
       )}
     </>
   );
@@ -338,9 +342,12 @@ function DashboardSankey({
       {sankeyData && sankeyData.totalIncome > 0 ? (
         <IncomeExpenseSankey data={sankeyData} />
       ) : (
-        <div className="min-h-[250px] sm:min-h-[300px] flex items-center justify-center text-muted-foreground text-sm rounded-xl bg-muted/40">
-          No income data
-        </div>
+        <EmptyState
+          compact
+          bordered={false}
+          title="No income data"
+          description="Add income transactions to see your income flow."
+        />
       )}
     </>
   );
@@ -368,9 +375,12 @@ function DashboardDetails({
         {merchantData && merchantData.length > 0 ? (
           <MerchantStats data={merchantData} previous={previousMerchants} />
         ) : (
-          <div className="p-6 sm:p-8 text-center text-muted-foreground text-sm rounded-xl bg-muted/40">
-            No merchant data
-          </div>
+          <EmptyState
+            compact
+            bordered={false}
+            icon={<StoreIcon className="h-10 w-10 text-muted-foreground" />}
+            title="No merchant data"
+          />
         )}
       </div>
 
@@ -381,9 +391,14 @@ function DashboardDetails({
         {transactionData && transactionData.length > 0 ? (
           <TransactionStats data={transactionData} />
         ) : (
-          <div className="p-6 sm:p-8 text-center text-muted-foreground text-sm rounded-xl bg-muted/40">
-            No transaction data
-          </div>
+          <EmptyState
+            compact
+            bordered={false}
+            icon={
+              <CreditCardIcon className="h-10 w-10 text-muted-foreground" />
+            }
+            title="No transaction data"
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Group 5 — Empty states

Part of a styling-consistency audit. The app had four-plus empty-state patterns: `py-16` with an icon in `rounded-full bg-muted`, `py-16` with an icon in `rounded-2xl bg-secondary shadow-sm`, a bordered `p-8` card, and plain `bg-muted/40` text blocks.

### Where to see the changes

**`apps/web/src/components/ui/empty-state.tsx`** *(new)* — the shared primitive: `icon` / `title` / `description`, plus `compact` (py-8) and `bordered` (default: `rounded-xl border-border bg-card shadow-soft`) options.

**`apps/web/src/components/ui/card-list.tsx`** — `CardListEmpty` now delegates to `EmptyState` (`bordered={false}`), so its callers keep working unchanged.

**`apps/web/src/components/merchants/merchant-list.tsx`** and **`apps/web/src/components/categories/category-list.tsx`** — the "no items" states now use `EmptyState` with `bordered={false}`. The routes already wrap these lists in a `rounded-xl border bg-card` surface, so this also removes a previously doubled border.

**`apps/web/src/components/dashboard/stats.tsx`** — the empty state now uses `EmptyState`, unifying the icon container on the `rounded-full bg-muted` style (was `rounded-2xl bg-secondary`).

**`apps/web/src/routes/dashboard.tsx`** — the chart, sankey, merchant, and transaction empty states now use compact `EmptyState` instead of ad-hoc `bg-muted/40` text blocks.