### PR TITLE
style(web): unify micro-label tracking and dialog/alert title treatment

### DIFF
--- a/apps/web/src/components/dashboard/period-insights.tsx
+++ b/apps/web/src/components/dashboard/period-insights.tsx
@@ -89,7 +89,7 @@ function InsightsRow({
 function InsightsHeaderRow() {
   return (
     <div
-      className={`grid ${INSIGHTS_TABLE_COLUMNS} items-center gap-2 py-2 text-xs uppercase tracking-widest text-muted-foreground border-b border-border/40`}
+      className={`grid ${INSIGHTS_TABLE_COLUMNS} items-center gap-2 py-2 text-xs uppercase tracking-wider text-muted-foreground border-b border-border/40`}
     >
       <span>Metric</span>
       <span className="text-right">Current</span>

--- a/apps/web/src/components/layout/page-header.tsx
+++ b/apps/web/src/components/layout/page-header.tsx
@@ -22,7 +22,7 @@ export function PageHeader({
         <div className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
           <div className="max-w-2xl space-y-1.5">
             {eyebrow && (
-              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                 {eyebrow}
               </p>
             )}

--- a/apps/web/src/components/transactions/transaction-report.tsx
+++ b/apps/web/src/components/transactions/transaction-report.tsx
@@ -447,7 +447,7 @@ export function TransactionReport() {
                 <div className="text-3xl font-bold text-foreground mb-1">
                   {reportData.summary.totalCount}
                 </div>
-                <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                <div className="text-xs uppercase tracking-wider text-muted-foreground">
                   Total Transactions
                 </div>
               </div>
@@ -458,7 +458,7 @@ export function TransactionReport() {
                     animate
                   />
                 </div>
-                <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                <div className="text-xs uppercase tracking-wider text-muted-foreground">
                   Total Amount
                 </div>
               </div>
@@ -469,7 +469,7 @@ export function TransactionReport() {
                     animate
                   />
                 </div>
-                <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                <div className="text-xs uppercase tracking-wider text-muted-foreground">
                   Average Amount
                 </div>
               </div>
@@ -481,7 +481,7 @@ export function TransactionReport() {
                       animate
                     />
                   </div>
-                  <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                  <div className="text-xs uppercase tracking-wider text-muted-foreground">
                     Monthly Average
                   </div>
                 </div>

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -39,7 +39,7 @@ function AlertTitle({ className, ...props }: ComponentProps<"div">) {
     <div
       data-slot="alert-title"
       className={cn(
-        "col-start-2 line-clamp-1 min-h-4 font-semibold tracking-wider uppercase",
+        "col-start-2 line-clamp-1 min-h-4 font-semibold",
         className
       )}
       {...props}
@@ -55,7 +55,7 @@ function AlertDescription({
     <div
       data-slot="alert-description"
       className={cn(
-        "text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed font-mono",
+        "text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -108,7 +108,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold font-mono uppercase tracking-wider", className)}
+      className={cn("text-lg leading-none font-semibold", className)}
       {...props}
     />
   )
@@ -121,7 +121,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-muted-foreground text-sm font-mono", className)}
+      className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Group 6 — Typography

Part of a styling-consistency audit. Uppercase micro-labels used five different letter-spacing values (`tracking-[0.16em]`, `tracking-[0.14em]`, `tracking-widest`, `tracking-wider`, `tracking-wide`), and dialog/alert titles used a `font-mono uppercase` treatment that matched nothing else in the app.

### Where to see the changes

Micro-labels are now one of two defined styles:
- **Eyebrow style** `tracking-[0.14em]` — `components/layout/page-header.tsx:25` (was `0.16em`), already matching `routes/dashboard.tsx:236`'s section titles.
- **Label style** `tracking-wider` — `components/dashboard/period-insights.tsx:92` (insights header, was `tracking-widest`) and `components/transactions/transaction-report.tsx` summary labels (4×, was `tracking-wide`). `stats.tsx` and the insights h3 already used `tracking-wider`.

**`apps/web/src/components/ui/dialog.tsx`** — `DialogTitle` drops the `font-mono uppercase tracking-wider` treatment and is now plain `text-lg font-semibold`, matching `CardTitle`. `DialogDescription` drops `font-mono`.

**`apps/web/src/components/ui/alert.tsx`** — `AlertTitle` drops `uppercase tracking-wider` (plain `font-semibold` now); `AlertDescription` drops `font-mono`. (`Alert` is not currently referenced in the app; this keeps the primitive consistent for future use.)

Deliberately left as-is (documented in the audit, but high-churn/low-value): the table's `font-mono` data styling and the base `h1-h4` scale vs explicit component heading classes.