### PR TITLE
feat(web): show build identifier on the settings page

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -4,6 +4,10 @@ FROM node:24-alpine AS builder
 ARG VITE_SERVER_URL=http://localhost:3000
 ENV VITE_SERVER_URL=${VITE_SERVER_URL}
 
+# Optional build identifier (e.g. short git SHA) injected by the build runner.
+ARG GIT_COMMIT=
+ENV VITE_GIT_COMMIT=${GIT_COMMIT}
+
 WORKDIR /app
 
 # Copy package files

--- a/apps/web/src/components/build-identifier.tsx
+++ b/apps/web/src/components/build-identifier.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+
+interface BuildIdentifierProps {
+  className?: string;
+}
+
+export function BuildIdentifier({ className }: BuildIdentifierProps) {
+  const commit = import.meta.env.VITE_GIT_COMMIT;
+  const buildTime = import.meta.env.VITE_BUILD_TIME;
+
+  if (!commit && !buildTime) {
+    return null;
+  }
+
+  return (
+    <p className={cn("font-mono text-xs text-muted-foreground/60", className)}>
+      {commit ? `build ${commit}` : null}
+      {commit && buildTime ? " · " : null}
+      {buildTime ? `built ${new Date(buildTime).toISOString()}` : null}
+    </p>
+  );
+}

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -4,6 +4,7 @@ import { X } from "lucide-react";
 import { useId, useState } from "react";
 import { toast } from "sonner";
 import { z } from "zod";
+import { BuildIdentifier } from "@/components/build-identifier";
 import { PageHeader } from "@/components/layout/page-header";
 import { ConfirmPassword } from "@/components/settings/confirm-password";
 import { Button } from "@/components/ui/button";
@@ -455,6 +456,8 @@ function RouteComponent() {
             </div>
           </Section>
         </div>
+
+        <BuildIdentifier />
       </div>
     </div>
   );

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import tailwindcss from "@tailwindcss/vite";
@@ -6,6 +7,23 @@ import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv } from "vite";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Resolve the git commit for the build identifier. Prefers an explicit
+// VITE_GIT_COMMIT (e.g. set as a Docker build ARG) and otherwise falls back
+// to the current HEAD when a .git directory is available at build time.
+function resolveGitCommit(env: Record<string, string>): string {
+  if (env.VITE_GIT_COMMIT) {
+    return env.VITE_GIT_COMMIT;
+  }
+  try {
+    return execSync("git rev-parse --short HEAD", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
 
 export default defineConfig(({ mode }) => {
   // Load env file based on mode (development/production)
@@ -17,6 +35,7 @@ export default defineConfig(({ mode }) => {
       "import.meta.env.VITE_BUILD_TIME": JSON.stringify(
         new Date().toISOString(),
       ),
+      "import.meta.env.VITE_GIT_COMMIT": JSON.stringify(resolveGitCommit(env)),
     },
     base: process.env.NODE_ENV === "production" ? "/" : "/",
     server: {


### PR DESCRIPTION
## What

Adds a small build identifier at the bottom of the settings page so it's easy to tell which build is deployed.

### Where to see the changes

- **`apps/web/vite.config.ts`** — injects `import.meta.env.VITE_GIT_COMMIT` at build time. Resolution order: explicit `VITE_GIT_COMMIT` env value first, otherwise `git rev-parse --short HEAD` (fallback `""` if git isn't available). `VITE_BUILD_TIME` injection was already present.
- **`apps/web/src/components/build-identifier.tsx`** *(new)* — renders `build <sha> · built <iso>` in a muted mono line; renders nothing when neither value is available. Reusable elsewhere (e.g. the site footer) if desired.
- **`apps/web/src/routes/settings.tsx`** — renders `<BuildIdentifier />` at the bottom, below the Privacy Mode section.
- **`apps/web/Dockerfile`** — adds an optional `GIT_COMMIT` build ARG (`ENV VITE_GIT_COMMIT`) because `.git` is excluded from the Docker build context, so the git fallback won't work in container builds. Pass e.g. `docker build --build-arg GIT_COMMIT=$(git rev-parse --short HEAD)` to label production builds.

### Verification

- Default path: bundle contains the current short SHA (`92d9c5f`).
- Env override path: `VITE_GIT_COMMIT=abc1234 npm run build` puts `abc1234` in the bundle.
- `check-types` and Biome pass.