### PR TITLE
feat(dashboard): migrate category pie chart to TanStack Charts

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,6 @@
 	},
 	"devDependencies": {
 		"@tanstack/react-query-devtools": "^5.90.2",
-		"server": "*",
 		"@tanstack/react-router-devtools": "^1.133.34",
 		"@tanstack/router-plugin": "^1.133.32",
 		"@types/d3-sankey": "^0.12.5",
@@ -22,15 +21,12 @@
 		"@types/react-dom": "^19.2.2",
 		"@vitejs/plugin-react": "^5.1.0",
 		"postcss": "^8.5.18",
+		"server": "*",
 		"tailwindcss": "^4.1.16",
 		"vite": "^7.3.5"
 	},
 	"dependencies": {
-		"@emotion/react": "^11.14.0",
-		"@emotion/styled": "^11.14.1",
 		"@hookform/resolvers": "^5.2.2",
-		"@mui/material": "^7.3.9",
-		"@mui/x-charts": "^8.28.2",
 		"@orpc/client": "^1.13.6",
 		"@orpc/openapi": "^1.13.9",
 		"@orpc/react-query": "^1.13.6",
@@ -47,6 +43,7 @@
 		"@radix-ui/react-switch": "^1.2.6",
 		"@radix-ui/react-tooltip": "^1.2.8",
 		"@tailwindcss/vite": "^4.1.16",
+		"@tanstack/charts": "^0.13.0",
 		"@tanstack/react-query": "^5.90.5",
 		"@tanstack/react-router": "^1.133.32",
 		"class-variance-authority": "^0.7.1",

--- a/apps/web/src/components/dashboard/category-pie-chart.tsx
+++ b/apps/web/src/components/dashboard/category-pie-chart.tsx
@@ -1,12 +1,14 @@
 import { defineChart } from "@tanstack/charts";
 import { focusGroupAngle, pie, polar, radialArc } from "@tanstack/charts/polar";
 import { Chart } from "@tanstack/charts/react";
+import { tooltip } from "@tanstack/charts/tooltip";
 import { useNavigate } from "@tanstack/react-router";
 import { ChevronDown } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { CurrencyAmount } from "@/components/ui/currency-amount";
 import { getColorFromCategoryId } from "@/lib/chart-colors";
+import { formatCurrency } from "@/lib/utils";
 import type {
   DashboardCategoryData,
   DashboardPeriodComparison,
@@ -150,6 +152,25 @@ export function CategoryPieChart({
           }),
         ],
         focus: focusGroupAngle,
+        tooltip: {
+          use: tooltip,
+          content: (points) => {
+            const point = points[0];
+            if (!point) {
+              return { rows: [] };
+            }
+            return {
+              title: point.datum.label,
+              color: point.color,
+              rows: [
+                {
+                  label: "Amount",
+                  value: formatCurrency(point.datum.value),
+                },
+              ],
+            };
+          },
+        },
       }),
     [pieData, activeItemId],
   );

--- a/apps/web/src/components/dashboard/category-pie-chart.tsx
+++ b/apps/web/src/components/dashboard/category-pie-chart.tsx
@@ -1,5 +1,6 @@
-import type { PieItemIdentifier } from "@mui/x-charts";
-import { PieChart } from "@mui/x-charts/PieChart";
+import { defineChart } from "@tanstack/charts";
+import { focusGroupAngle, pie, polar, radialArc } from "@tanstack/charts/polar";
+import { Chart } from "@tanstack/charts/react";
 import { useNavigate } from "@tanstack/react-router";
 import { ChevronDown } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -113,33 +114,63 @@ export function CategoryPieChart({
     [navigate],
   );
 
-  // Handle item click from pie chart
-  const handleItemClick = useCallback(
-    (_event: React.MouseEvent, params: PieItemIdentifier) => {
-      const item = chartData[params.dataIndex];
-      if (item?.categoryId) {
-        handleCategoryClick(item.categoryId);
-      }
-    },
-    [chartData, handleCategoryClick],
+  // Allocate the chart data into angular slices
+  const pieData = useMemo(
+    () => pie(chartData, { value: (item) => item.value }),
+    [chartData],
   );
 
-  // Handle highlight change (hover)
-  const handleHighlightChange = useCallback(
-    (
-      highlightedItem: {
-        dataIndex?: number;
-        seriesId?: number | string;
-      } | null,
-    ) => {
-      if (highlightedItem?.dataIndex !== undefined) {
-        const item = chartData[highlightedItem.dataIndex];
-        setActiveItemId(item?.id ?? null);
-      } else {
-        setActiveItemId(null);
+  // Rebuild the definition whenever the active slice changes so the fill
+  // accessor can fade non-active slices (radialArc has no declarative states).
+  const definition = useMemo(
+    () =>
+      defineChart({
+        marks: [
+          polar({
+            inset: 4,
+            radiusRatio: 0.96,
+            marks: [
+              radialArc(pieData, {
+                key: (datum) => datum.categoryId,
+                innerRadius: ({ radius }) => radius * 0.55,
+                cornerRadius: 2,
+                stroke: "var(--card)",
+                strokeWidth: 2,
+                fill: (datum) => {
+                  if (
+                    activeItemId !== null &&
+                    activeItemId !== datum.categoryId
+                  ) {
+                    return `color-mix(in srgb, ${datum.color} 22%, transparent)`;
+                  }
+                  return datum.color;
+                },
+              }),
+            ],
+          }),
+        ],
+        focus: focusGroupAngle,
+      }),
+    [pieData, activeItemId],
+  );
+
+  // Keep the legend in sync with the hovered slice
+  const handleFocusChange = useCallback(
+    (point: { datum: ChartItem } | null) => {
+      setActiveItemId(point?.datum.categoryId ?? null);
+    },
+    [],
+  );
+
+  // Handle item click from pie chart
+  const handleItemClick = useCallback(
+    (point: { datum: ChartItem } | null) => {
+      const categoryId = point?.datum.categoryId;
+      if (categoryId) {
+        handleCategoryClick(categoryId);
       }
     },
-    [chartData],
+    [handleCategoryClick],
   );
 
   if (!data || data.length === 0) {
@@ -163,35 +194,13 @@ export function CategoryPieChart({
           {/* Chart Section */}
           <div className="flex-shrink-0 flex justify-center">
             <div className="relative w-[220px] h-[220px]">
-              <PieChart
-                series={[
-                  {
-                    data: chartData,
-                    innerRadius: 50,
-                    outerRadius: 85,
-                    paddingAngle: 0.5,
-                    cornerRadius: 2,
-                    highlightScope: { fade: "global", highlight: "item" },
-                    faded: {
-                      innerRadius: 50,
-                      additionalRadius: -2,
-                      color: "gray",
-                    },
-                    valueFormatter: (item) => {
-                      const dollars = item.value / 100;
-                      return new Intl.NumberFormat("en-US", {
-                        style: "currency",
-                        currency: "USD",
-                      }).format(dollars);
-                    },
-                  },
-                ]}
+              <Chart
+                definition={definition}
                 width={220}
                 height={220}
-                onItemClick={handleItemClick}
-                onHighlightChange={handleHighlightChange}
-                skipAnimation
-                hideLegend
+                ariaLabel="Category spending breakdown"
+                onFocusChange={handleFocusChange}
+                onSelect={handleItemClick}
               />
 
               {/* Center Text */}

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,11 +50,7 @@
 		"apps/web": {
 			"version": "0.0.0",
 			"dependencies": {
-				"@emotion/react": "^11.14.0",
-				"@emotion/styled": "^11.14.1",
 				"@hookform/resolvers": "^5.2.2",
-				"@mui/material": "^7.3.9",
-				"@mui/x-charts": "^8.28.2",
 				"@orpc/client": "^1.13.6",
 				"@orpc/openapi": "^1.13.9",
 				"@orpc/react-query": "^1.13.6",
@@ -71,6 +67,7 @@
 				"@radix-ui/react-switch": "^1.2.6",
 				"@radix-ui/react-tooltip": "^1.2.8",
 				"@tailwindcss/vite": "^4.1.16",
+				"@tanstack/charts": "^0.13.0",
 				"@tanstack/react-query": "^5.90.5",
 				"@tanstack/react-router": "^1.133.32",
 				"class-variance-authority": "^0.7.1",
@@ -126,6 +123,7 @@
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
 			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.29.7",
@@ -188,6 +186,7 @@
 			"version": "7.29.8",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
 			"integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/parser": "^7.29.8",
@@ -221,6 +220,7 @@
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
 			"integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -230,6 +230,7 @@
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
 			"integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/traverse": "^7.29.7",
@@ -271,6 +272,7 @@
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
 			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -280,6 +282,7 @@
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
 			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -313,6 +316,7 @@
 			"version": "7.29.8",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
 			"integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/types": "^7.29.8"
@@ -356,19 +360,11 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/runtime": {
-			"version": "7.29.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/template": {
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
 			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.29.7",
@@ -383,6 +379,7 @@
 			"version": "7.29.8",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
 			"integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.29.7",
@@ -401,6 +398,7 @@
 			"version": "7.29.8",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
 			"integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.29.7",
@@ -617,152 +615,6 @@
 			"integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
 			"dev": true,
 			"license": "Apache-2.0"
-		},
-		"node_modules/@emotion/babel-plugin": {
-			"version": "11.13.5",
-			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
-			"integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-module-imports": "^7.16.7",
-				"@babel/runtime": "^7.18.3",
-				"@emotion/hash": "^0.9.2",
-				"@emotion/memoize": "^0.9.0",
-				"@emotion/serialize": "^1.3.3",
-				"babel-plugin-macros": "^3.1.0",
-				"convert-source-map": "^1.5.0",
-				"escape-string-regexp": "^4.0.0",
-				"find-root": "^1.1.0",
-				"source-map": "^0.5.7",
-				"stylis": "4.2.0"
-			}
-		},
-		"node_modules/@emotion/cache": {
-			"version": "11.14.0",
-			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
-			"integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
-			"license": "MIT",
-			"dependencies": {
-				"@emotion/memoize": "^0.9.0",
-				"@emotion/sheet": "^1.4.0",
-				"@emotion/utils": "^1.4.2",
-				"@emotion/weak-memoize": "^0.4.0",
-				"stylis": "4.2.0"
-			}
-		},
-		"node_modules/@emotion/hash": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-			"integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-			"license": "MIT"
-		},
-		"node_modules/@emotion/is-prop-valid": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
-			"integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
-			"license": "MIT",
-			"dependencies": {
-				"@emotion/memoize": "^0.9.0"
-			}
-		},
-		"node_modules/@emotion/memoize": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-			"integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-			"license": "MIT"
-		},
-		"node_modules/@emotion/react": {
-			"version": "11.14.0",
-			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
-			"integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.18.3",
-				"@emotion/babel-plugin": "^11.13.5",
-				"@emotion/cache": "^11.14.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
-				"@emotion/utils": "^1.4.2",
-				"@emotion/weak-memoize": "^0.4.0",
-				"hoist-non-react-statics": "^3.3.1"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@emotion/serialize": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
-			"integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
-			"license": "MIT",
-			"dependencies": {
-				"@emotion/hash": "^0.9.2",
-				"@emotion/memoize": "^0.9.0",
-				"@emotion/unitless": "^0.10.0",
-				"@emotion/utils": "^1.4.2",
-				"csstype": "^3.0.2"
-			}
-		},
-		"node_modules/@emotion/sheet": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
-			"integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
-			"license": "MIT"
-		},
-		"node_modules/@emotion/styled": {
-			"version": "11.14.1",
-			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
-			"integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.18.3",
-				"@emotion/babel-plugin": "^11.13.5",
-				"@emotion/is-prop-valid": "^1.3.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
-				"@emotion/utils": "^1.4.2"
-			},
-			"peerDependencies": {
-				"@emotion/react": "^11.0.0-rc.0",
-				"react": ">=16.8.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@emotion/unitless": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
-			"integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-			"license": "MIT"
-		},
-		"node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-			"integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"react": ">=16.8.0"
-			}
-		},
-		"node_modules/@emotion/utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
-			"integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
-			"license": "MIT"
-		},
-		"node_modules/@emotion/weak-memoize": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
-			"integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
-			"license": "MIT"
 		},
 		"node_modules/@esbuild-kit/core-utils": {
 			"version": "3.3.2",
@@ -1409,312 +1261,6 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
-		"node_modules/@mui/core-downloads-tracker": {
-			"version": "7.3.11",
-			"resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.11.tgz",
-			"integrity": "sha512-a7I/b/nBTdXYz2cOSlEmkQ9WWE1x8FHpqMhFPp+Y1VPFxcOw91G5ELOHARQAGSPy5V+UCgJua6K/1x70bAtQPw==",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mui-org"
-			}
-		},
-		"node_modules/@mui/material": {
-			"version": "7.3.11",
-			"resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.11.tgz",
-			"integrity": "sha512-yq8bPc3LxOwKRWpcjRgDkYFmpM6aKlARfESTmOQcvLYFeJwtHte2tw6hJDrb8sk8wcvpDprHEHVaoUU0MslIkw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.28.6",
-				"@mui/core-downloads-tracker": "^7.3.11",
-				"@mui/system": "^7.3.11",
-				"@mui/types": "^7.4.12",
-				"@mui/utils": "^7.3.11",
-				"@popperjs/core": "^2.11.8",
-				"@types/react-transition-group": "^4.4.12",
-				"clsx": "^2.1.1",
-				"csstype": "^3.2.3",
-				"prop-types": "^15.8.1",
-				"react-is": "^19.2.3",
-				"react-transition-group": "^4.4.5"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mui-org"
-			},
-			"peerDependencies": {
-				"@emotion/react": "^11.5.0",
-				"@emotion/styled": "^11.3.0",
-				"@mui/material-pigment-css": "^7.3.11",
-				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@emotion/react": {
-					"optional": true
-				},
-				"@emotion/styled": {
-					"optional": true
-				},
-				"@mui/material-pigment-css": {
-					"optional": true
-				},
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@mui/private-theming": {
-			"version": "7.3.11",
-			"resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.11.tgz",
-			"integrity": "sha512-9B+YKms0fRHbNrqp9tOT/DNbNnU5gyvJ1o3qAGXfq8GmZcbJnE3At9x07Zr/o0pkhzg4aDdwXVqe4+AcgtOCPA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.28.6",
-				"@mui/utils": "^7.3.11",
-				"prop-types": "^15.8.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mui-org"
-			},
-			"peerDependencies": {
-				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@mui/styled-engine": {
-			"version": "7.3.10",
-			"resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.10.tgz",
-			"integrity": "sha512-WxE9SiF8xskAQqGjsp0poXCkCqsoXFEsSr0HBXfApmGHR+DBnXRp+z46Vsltg4gpPM4Z96DeAQRpeAOnhNg7Ng==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.28.6",
-				"@emotion/cache": "^11.14.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/sheet": "^1.4.0",
-				"csstype": "^3.2.3",
-				"prop-types": "^15.8.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mui-org"
-			},
-			"peerDependencies": {
-				"@emotion/react": "^11.4.1",
-				"@emotion/styled": "^11.3.0",
-				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@emotion/react": {
-					"optional": true
-				},
-				"@emotion/styled": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@mui/system": {
-			"version": "7.3.11",
-			"resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.11.tgz",
-			"integrity": "sha512-7izwGWdNawAKpBKcRlx7f2gFnAAjmASBWvMcyX4YYEeLOFsbfGRbUYGInvnAcUeql3rPxI7F9Ft4oY2OLRz44g==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.28.6",
-				"@mui/private-theming": "^7.3.11",
-				"@mui/styled-engine": "^7.3.10",
-				"@mui/types": "^7.4.12",
-				"@mui/utils": "^7.3.11",
-				"clsx": "^2.1.1",
-				"csstype": "^3.2.3",
-				"prop-types": "^15.8.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mui-org"
-			},
-			"peerDependencies": {
-				"@emotion/react": "^11.5.0",
-				"@emotion/styled": "^11.3.0",
-				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@emotion/react": {
-					"optional": true
-				},
-				"@emotion/styled": {
-					"optional": true
-				},
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@mui/types": {
-			"version": "7.4.12",
-			"resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
-			"integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.28.6"
-			},
-			"peerDependencies": {
-				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@mui/utils": {
-			"version": "7.3.11",
-			"resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.11.tgz",
-			"integrity": "sha512-XTjGnifwteg71/ij+0e7Y7d+hwyntMYP5wPoA/g2drdGH+Flkvjwy0OfrVpKBbaOvofq4zU/LIyUZyKgmWu18g==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.28.6",
-				"@mui/types": "^7.4.12",
-				"@types/prop-types": "^15.7.15",
-				"clsx": "^2.1.1",
-				"prop-types": "^15.8.1",
-				"react-is": "^19.2.3"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mui-org"
-			},
-			"peerDependencies": {
-				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@mui/x-charts": {
-			"version": "8.29.2",
-			"resolved": "https://registry.npmjs.org/@mui/x-charts/-/x-charts-8.29.2.tgz",
-			"integrity": "sha512-s0f0gstCEBO4HV1aj4wNapL6RYREO+YyFLs4cSKm8bu347AuADngBtepNSCXuzsCQ+C+PxAlBoCy2a1ssTxMuA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.28.4",
-				"@mui/utils": "^7.3.5",
-				"@mui/x-charts-vendor": "8.29.0",
-				"@mui/x-internal-gestures": "0.5.0",
-				"@mui/x-internals": "8.29.2",
-				"bezier-easing": "^2.1.0",
-				"clsx": "^2.1.1",
-				"prop-types": "^15.8.1",
-				"reselect": "^5.1.1",
-				"use-sync-external-store": "^1.6.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"@emotion/react": "^11.9.0",
-				"@emotion/styled": "^11.8.1",
-				"@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
-				"@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
-				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@emotion/react": {
-					"optional": true
-				},
-				"@emotion/styled": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@mui/x-charts-vendor": {
-			"version": "8.29.0",
-			"resolved": "https://registry.npmjs.org/@mui/x-charts-vendor/-/x-charts-vendor-8.29.0.tgz",
-			"integrity": "sha512-nYjgW337QxvCJXct8b0UIir9ELDjMEfWSmMVSfUQsEjn3ZD5jjK3MQVZSHSM1hP79PZcjRQIAuWI1fHkqG04ug==",
-			"license": "MIT AND ISC",
-			"dependencies": {
-				"@babel/runtime": "^7.28.4",
-				"@types/d3-array": "^3.2.2",
-				"@types/d3-color": "^3.1.3",
-				"@types/d3-format": "^3.0.4",
-				"@types/d3-interpolate": "^3.0.4",
-				"@types/d3-path": "^3.1.1",
-				"@types/d3-scale": "^4.0.9",
-				"@types/d3-shape": "^3.1.8",
-				"@types/d3-time": "^3.0.4",
-				"@types/d3-time-format": "^4.0.3",
-				"@types/d3-timer": "^3.0.2",
-				"d3-array": "^3.2.4",
-				"d3-color": "^3.1.0",
-				"d3-format": "^3.1.2",
-				"d3-interpolate": "^3.0.1",
-				"d3-path": "^3.1.0",
-				"d3-scale": "^4.0.2",
-				"d3-shape": "^3.2.0",
-				"d3-time": "^3.1.0",
-				"d3-time-format": "^4.1.0",
-				"d3-timer": "^3.0.1",
-				"flatqueue": "^3.0.0",
-				"internmap": "^2.0.3"
-			}
-		},
-		"node_modules/@mui/x-internal-gestures": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@mui/x-internal-gestures/-/x-internal-gestures-0.5.0.tgz",
-			"integrity": "sha512-LTnaD8WAWld9ecW8Q5tO4Sq2ucyMWca4SKDu6Cx+0RHO3XfgMa7NxB7aBzldAYMN8QrSquBVdu8Zcf9cnp8qwQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.28.4"
-			}
-		},
-		"node_modules/@mui/x-internals": {
-			"version": "8.29.2",
-			"resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.29.2.tgz",
-			"integrity": "sha512-TLILyHia5NHh3MGErFDh0bXZ4V6iS45hdStofsV5wklF6dpgZjduo65oJB0h81mI5mexNlhHANEVfw0KV6BxBg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.28.4",
-				"@mui/utils": "^7.3.5",
-				"reselect": "^5.1.1",
-				"use-sync-external-store": "^1.6.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mui-org"
-			},
-			"peerDependencies": {
-				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-			}
-		},
 		"node_modules/@napi-rs/lzma-linux-x64-gnu": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
@@ -2021,16 +1567,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@popperjs/core": {
-			"version": "2.11.8",
-			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-			"integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/popperjs"
 			}
 		},
 		"node_modules/@radix-ui/number": {
@@ -3539,6 +3075,89 @@
 				"vite": "^5.2.0 || ^6 || ^7 || ^8"
 			}
 		},
+		"node_modules/@tanstack/charts": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@tanstack/charts/-/charts-0.13.0.tgz",
+			"integrity": "sha512-yliQoguzGDUGU/xLPEutY8Tm0NbVWFbTX2TuJ7kjtxA/ohoKeCmlnbCa4VMpyQOmuTe8eo3Oiq8ePP0Y24ck8w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-force": "^3.0.10",
+				"@types/d3-geo": "^3.1.0",
+				"@types/d3-hierarchy": "^3.1.7",
+				"@types/d3-sankey": "^0.12.5",
+				"@types/d3-shape": "^3.1.8",
+				"d3-array": "3.2.4",
+				"d3-brush": "3.0.0",
+				"d3-contour": "4.0.2",
+				"d3-delaunay": "6.0.4",
+				"d3-force": "3.0.0",
+				"d3-geo": "3.1.1",
+				"d3-hexbin": "0.2.2",
+				"d3-hierarchy": "3.1.2",
+				"d3-sankey": "0.12.3",
+				"d3-scale": "4.0.2",
+				"d3-selection": "3.0.0",
+				"d3-shape": "3.2.0",
+				"d3-zoom": "3.0.0",
+				"tslib": "^2.8.1"
+			},
+			"peerDependencies": {
+				"@angular/core": ">=19",
+				"@angular/platform-browser": ">=19",
+				"alpinejs": ">=3.15",
+				"lit": ">=3.1.3",
+				"octane": "^0.1.13",
+				"preact": ">=10",
+				"react": "^19.0.0",
+				"react-dom": "^19.0.0",
+				"react-native": "^0.86.0",
+				"react-native-svg": ">=15.15.4 <16",
+				"solid-js": ">=1.8",
+				"svelte": "^5.20.0",
+				"vue": ">=3.5"
+			},
+			"peerDependenciesMeta": {
+				"@angular/core": {
+					"optional": true
+				},
+				"@angular/platform-browser": {
+					"optional": true
+				},
+				"alpinejs": {
+					"optional": true
+				},
+				"lit": {
+					"optional": true
+				},
+				"octane": {
+					"optional": true
+				},
+				"preact": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				},
+				"react-native": {
+					"optional": true
+				},
+				"react-native-svg": {
+					"optional": true
+				},
+				"solid-js": {
+					"optional": true
+				},
+				"svelte": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@tanstack/history": {
 			"version": "1.162.1",
 			"resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.162.1.tgz",
@@ -4049,32 +3668,26 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/d3-array": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-			"integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+		"node_modules/@types/d3-force": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+			"integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
 			"license": "MIT"
 		},
-		"node_modules/@types/d3-color": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-			"integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-format": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
-			"integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-interpolate": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-			"integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+		"node_modules/@types/d3-geo": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.1.tgz",
+			"integrity": "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/d3-color": "*"
+				"@types/geojson": "*"
 			}
+		},
+		"node_modules/@types/d3-hierarchy": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+			"integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+			"license": "MIT"
 		},
 		"node_modules/@types/d3-path": {
 			"version": "3.1.1",
@@ -4086,7 +3699,6 @@
 			"version": "0.12.5",
 			"resolved": "https://registry.npmjs.org/@types/d3-sankey/-/d3-sankey-0.12.5.tgz",
 			"integrity": "sha512-/3RZSew0cLAtzGQ+C89hq/Rp3H20QJuVRSqFy6RKLe7E0B8kd2iOS1oBsodrgds4PcNVpqWhdUEng/SHvBcJ6Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/d3-shape": "^1"
@@ -4096,26 +3708,15 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.11.tgz",
 			"integrity": "sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/d3-sankey/node_modules/@types/d3-shape": {
 			"version": "1.3.12",
 			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.12.tgz",
 			"integrity": "sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/d3-path": "^1"
-			}
-		},
-		"node_modules/@types/d3-scale": {
-			"version": "4.0.9",
-			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-			"integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-time": "*"
 			}
 		},
 		"node_modules/@types/d3-shape": {
@@ -4127,28 +3728,16 @@
 				"@types/d3-path": "*"
 			}
 		},
-		"node_modules/@types/d3-time": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-			"integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-time-format": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
-			"integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-timer": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-			"integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-			"license": "MIT"
-		},
 		"node_modules/@types/estree": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
 			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/geojson": {
+			"version": "7946.0.16",
+			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
@@ -4160,12 +3749,6 @@
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
-		},
-		"node_modules/@types/parse-json": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-			"integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-			"license": "MIT"
 		},
 		"node_modules/@types/pg": {
 			"version": "8.21.0",
@@ -4179,16 +3762,11 @@
 				"pg-types": "^2.2.0"
 			}
 		},
-		"node_modules/@types/prop-types": {
-			"version": "15.7.15",
-			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-			"license": "MIT"
-		},
 		"node_modules/@types/react": {
 			"version": "19.2.18",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
 			"integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"csstype": "^3.2.2"
@@ -4202,15 +3780,6 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
-			}
-		},
-		"node_modules/@types/react-transition-group": {
-			"version": "4.4.12",
-			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
-			"integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@types/react": "*"
 			}
 		},
 		"node_modules/@types/triple-beam": {
@@ -4360,21 +3929,6 @@
 				"@babel/types": "^7.23.6"
 			}
 		},
-		"node_modules/babel-plugin-macros": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.12.5",
-				"cosmiconfig": "^7.0.0",
-				"resolve": "^1.19.0"
-			},
-			"engines": {
-				"node": ">=10",
-				"npm": ">=6"
-			}
-		},
 		"node_modules/baseline-browser-mapping": {
 			"version": "2.11.13",
 			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
@@ -4401,12 +3955,6 @@
 			"engines": {
 				"node": ">= 18"
 			}
-		},
-		"node_modules/bezier-easing": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
-			"integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==",
-			"license": "MIT"
 		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
@@ -4474,15 +4022,6 @@
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/callsites": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/caniuse-lite": {
 			"version": "1.0.30001809",
@@ -4654,12 +4193,6 @@
 				"node": ">=20"
 			}
 		},
-		"node_modules/convert-source-map": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-			"license": "MIT"
-		},
 		"node_modules/cookie": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -4679,35 +4212,11 @@
 			"integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
 			"license": "MIT"
 		},
-		"node_modules/cosmiconfig": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/parse-json": "^4.0.0",
-				"import-fresh": "^3.2.1",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/cosmiconfig/node_modules/yaml": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-			"integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-			"license": "ISC",
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/csstype": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/csv-parse": {
@@ -4728,6 +4237,22 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/d3-brush": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+			"integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-drag": "2 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-selection": "3",
+				"d3-transition": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/d3-color": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -4737,10 +4262,106 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/d3-contour": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+			"integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-delaunay": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+			"integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+			"license": "ISC",
+			"dependencies": {
+				"delaunator": "5"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dispatch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+			"integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-drag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+			"integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-selection": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-ease": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+			"integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-force": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+			"integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-quadtree": "1 - 3",
+				"d3-timer": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/d3-format": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
 			"integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-geo": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+			"integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2.5.0 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-hexbin": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/d3-hexbin/-/d3-hexbin-0.2.2.tgz",
+			"integrity": "sha512-KS3fUT2ReD4RlGCjvCEm1RgMtp2NFZumdMu4DBzQK8AZv3fXRM6Xm8I4fSU07UXvH4xxg03NwWKWdvxfS/yc4w==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/d3-hierarchy": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+			"integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -4762,6 +4383,15 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
 			"integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-quadtree": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+			"integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -4823,6 +4453,15 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/d3-selection": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/d3-shape": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
@@ -4868,6 +4507,41 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/d3-transition": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+			"integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3",
+				"d3-dispatch": "1 - 3",
+				"d3-ease": "1 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-timer": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"d3-selection": "2 - 3"
+			}
+		},
+		"node_modules/d3-zoom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+			"integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-drag": "2 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-selection": "2 - 3",
+				"d3-transition": "2 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/date-fns": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
@@ -4888,6 +4562,7 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -4899,6 +4574,15 @@
 				"supports-color": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/delaunator": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+			"integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+			"license": "ISC",
+			"dependencies": {
+				"robust-predicates": "^3.0.2"
 			}
 		},
 		"node_modules/detect-libc": {
@@ -4937,16 +4621,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/dom-helpers": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-			"integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.8.7",
-				"csstype": "^3.0.2"
 			}
 		},
 		"node_modules/dotenv": {
@@ -5148,24 +4822,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/error-ex": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-			"integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-			"license": "MIT",
-			"dependencies": {
-				"is-arrayish": "^0.2.1"
-			}
-		},
-		"node_modules/es-errors": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/esbuild": {
 			"version": "0.28.2",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
@@ -5215,18 +4871,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/escape-string-regexp": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/eventemitter3": {
@@ -5299,18 +4943,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/find-root": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-			"license": "MIT"
-		},
-		"node_modules/flatqueue": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/flatqueue/-/flatqueue-3.1.0.tgz",
-			"integrity": "sha512-Ia4qIYrrsEqIRx3c3XhkT+QDLQuUV5ovsr6ah1rIgKT5wclhoGK3lAMS1bWRAWxlx7wtlTBpV7QXB5d9fOSRxA==",
-			"license": "ISC"
-		},
 		"node_modules/fn.name": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
@@ -5329,15 +4961,6 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
-		"node_modules/function-bind": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/gensync": {
@@ -5435,33 +5058,6 @@
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"license": "ISC"
 		},
-		"node_modules/hasown": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-			"license": "MIT",
-			"dependencies": {
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/hoist-non-react-statics": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"react-is": "^16.7.0"
-			}
-		},
-		"node_modules/hoist-non-react-statics/node_modules/react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"license": "MIT"
-		},
 		"node_modules/hono": {
 			"version": "4.13.1",
 			"resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
@@ -5497,22 +5093,6 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/import-fresh": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-			"license": "MIT",
-			"dependencies": {
-				"parent-module": "^1.0.0",
-				"resolve-from": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -5528,12 +5108,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/is-arrayish": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-			"license": "MIT"
-		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -5545,21 +5119,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/is-core-module": {
-			"version": "2.16.2",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
-			"integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
-			"license": "MIT",
-			"dependencies": {
-				"hasown": "^2.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-extglob": {
@@ -5645,12 +5204,14 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/jsesc": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
 			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"jsesc": "bin/jsesc"
@@ -5658,12 +5219,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/json-parse-even-better-errors": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"license": "MIT"
 		},
 		"node_modules/json-schema-typed": {
 			"version": "8.0.2",
@@ -5951,12 +5506,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/lines-and-columns": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-			"license": "MIT"
-		},
 		"node_modules/lint-staged": {
 			"version": "16.4.0",
 			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
@@ -6051,18 +5600,6 @@
 			},
 			"engines": {
 				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"license": "MIT",
-			"dependencies": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			},
-			"bin": {
-				"loose-envify": "cli.js"
 			}
 		},
 		"node_modules/lru-cache": {
@@ -6231,15 +5768,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/one-time": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
@@ -6271,46 +5799,11 @@
 			"integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
 			"license": "MIT"
 		},
-		"node_modules/parent-module": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-			"license": "MIT",
-			"dependencies": {
-				"callsites": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/parse-json": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.0.0",
-				"error-ex": "^1.3.1",
-				"json-parse-even-better-errors": "^2.3.0",
-				"lines-and-columns": "^1.1.6"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"license": "MIT"
-		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -6526,23 +6019,6 @@
 				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
-		"node_modules/prop-types": {
-			"version": "15.8.1",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-			"license": "MIT",
-			"dependencies": {
-				"loose-envify": "^1.4.0",
-				"object-assign": "^4.1.1",
-				"react-is": "^16.13.1"
-			}
-		},
-		"node_modules/prop-types/node_modules/react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"license": "MIT"
-		},
 		"node_modules/queue-lit": {
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
@@ -6642,12 +6118,6 @@
 				"react": "^16.8.0 || ^17 || ^18 || ^19"
 			}
 		},
-		"node_modules/react-is": {
-			"version": "19.2.8",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
-			"integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
-			"license": "MIT"
-		},
 		"node_modules/react-refresh": {
 			"version": "0.18.0",
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -6727,22 +6197,6 @@
 				}
 			}
 		},
-		"node_modules/react-transition-group": {
-			"version": "4.4.5",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-			"integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@babel/runtime": "^7.5.5",
-				"dom-helpers": "^5.0.1",
-				"loose-envify": "^1.4.0",
-				"prop-types": "^15.6.2"
-			},
-			"peerDependencies": {
-				"react": ">=16.6.0",
-				"react-dom": ">=16.6.0"
-			}
-		},
 		"node_modules/readable-stream": {
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -6769,42 +6223,6 @@
 			"funding": {
 				"type": "individual",
 				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/reselect": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
-			"integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
-			"license": "MIT"
-		},
-		"node_modules/resolve": {
-			"version": "1.22.12",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-			"integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"is-core-module": "^2.16.1",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			},
-			"bin": {
-				"resolve": "bin/resolve"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/resolve-from": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/resolve-pkg-maps": {
@@ -6851,6 +6269,12 @@
 			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/robust-predicates": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+			"integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+			"license": "Unlicense"
 		},
 		"node_modules/rollup": {
 			"version": "4.62.4",
@@ -7053,15 +6477,6 @@
 				}
 			}
 		},
-		"node_modules/source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7160,24 +6575,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
-		"node_modules/stylis": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-			"integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-			"license": "MIT"
-		},
-		"node_modules/supports-preserve-symlinks-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/tagged-tag": {


### PR DESCRIPTION
## Summary

Migrates the dashboard's category breakdown donut from MUI X Charts to TanStack Charts.

## Changes

- Replace the MUI `PieChart` in `category-pie-chart.tsx` with `@tanstack/charts` polar marks (`pie` + `polar` + `radialArc` + `focusGroupAngle`).
- Preserve feature parity:
  - Per-category colors via `getColorFromCategoryId`
  - Hover fade of non-active slices + legend highlight sync (`onFocusChange`)
  - Click slice to navigate to filtered transactions (`onSelect`)
  - Center total overlay and scrollable legend (unchanged)
  - Subtle theme-aware slice border (`stroke: var(--card)`, width 2)
- Add `@tanstack/charts@0.13.0` dependency; remove now-unused `@mui/x-charts`, `@mui/material`, `@emotion/react`, `@emotion/styled`.

## Notes

- `@tanstack/charts` is pre-alpha (0.13.0); API may shift between releases.
- The income/expense Sankey still uses the custom d3-sankey SVG and will be migrated separately.

## Verification

- `npm run check-types`, `vite build`, and Biome pass.
- Manually verified in the browser: donut renders with category colors, hover fades + highlights legend, click navigates.