### PR TITLE
feat(external-api): add delete transaction endpoint

### DIFF
--- a/apps/server/src/external-api-docs.md
+++ b/apps/server/src/external-api-docs.md
@@ -166,6 +166,27 @@ Returns `404` if the transaction, merchant, or category is not found. Returns `4
 
 ---
 
+## DELETE /api/transactions/:id
+
+Delete a transaction permanently.
+
+### Request Headers
+- `Authorization: Bearer <token>` (required)
+
+### Path Parameters
+- `id` (string, required): Transaction UUID.
+
+### Response
+```json
+{
+  "message": "Transaction deleted"
+}
+```
+
+Returns `404` if the transaction is not found. Returns `403` if the transaction belongs to another user.
+
+---
+
 ## GET /api/transactions/search
 
 Broad search across transactions. Matches when the query appears in `transactionDetails`, `notes`, `merchant.name`, or `category.name`.

--- a/apps/server/src/external-api.ts
+++ b/apps/server/src/external-api.ts
@@ -528,6 +528,64 @@ externalApi.patch("/transactions/:id", async (c) => {
   }
 });
 
+// DELETE /transactions/:id - Delete a transaction
+externalApi.delete("/transactions/:id", async (c) => {
+  try {
+    const userId = await getUserIdFromBearerToken(c);
+    if (!userId) {
+      return c.json(
+        { error: "Missing, invalid, or expired Authorization header" },
+        401,
+      );
+    }
+
+    const transactionId = c.req.param("id");
+
+    const currentTransaction = await validateTransactionOwnership(
+      transactionId,
+      userId,
+    );
+
+    if (currentTransaction.merchantId) {
+      await handleKeywordRemoval(
+        currentTransaction,
+        currentTransaction.merchantId,
+        transactionId,
+      );
+    }
+
+    const deletedTransactions = await db
+      .delete(transaction)
+      .where(eq(transaction.id, transactionId))
+      .returning();
+
+    if (!deletedTransactions || deletedTransactions.length === 0) {
+      return c.json({ error: "Transaction not found" }, 404);
+    }
+
+    return c.json({ message: "Transaction deleted" });
+  } catch (error) {
+    logger.error("API transaction deletion failed", {
+      error,
+      metadata: {
+        method: c.req.method,
+        url: c.req.url,
+      },
+    });
+
+    if (error instanceof Error) {
+      if (error.message === "Transaction not found") {
+        return c.json({ error: error.message }, 404);
+      }
+      if (error.message === "Unauthorized to update this transaction") {
+        return c.json({ error: error.message }, 403);
+      }
+      return c.json({ error: error.message }, 500);
+    }
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
 // GET /categories - List categories for the authenticated user
 externalApi.get("/categories", async (c) => {
   try {


### PR DESCRIPTION
Adds a `DELETE /api/transactions/:id` endpoint to the external REST API and documents it in `external-api-docs.md`.

- Verifies the bearer token and transaction ownership (returns 404 / 403 on failure)
- Removes merchant keywords matching the deleted transaction's details before deletion
- Mirrors the error handling pattern of the existing PATCH endpoint