### PR TITLE
fix(web): throw signin redirect and collapse auth state to one encoding

### DIFF
--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -59,7 +59,6 @@ export const useSessionFetch = async () => {
       ...session,
       ...data[1],
       meta: data[0],
-      isAuthenticated: true,
     };
   } catch (error) {
     if (error instanceof ORPCError && error.code === "UNAUTHORIZED") {
@@ -74,7 +73,6 @@ export const useSessionFetch = async () => {
         webhookUrls: [],
       },
       meta: { unreviewedTransactionCount: 0, earliestTransactionDate: null },
-      isAuthenticated: true,
     };
   }
 };

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -10,7 +10,7 @@ const router = createRouter({
   routeTree,
   defaultPreload: "intent",
   defaultPendingComponent: () => <Loader />,
-  context: { orpc, queryClient },
+  context: { orpc, queryClient, auth: null, isAuthenticated: false },
   Wrap: function WrapComponent({ children }: { children: ReactNode }) {
     return (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -19,7 +19,7 @@ import { TopNav } from "@/components/layout/top-nav";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
-import { useSession, useSessionFetch } from "@/lib/auth-client";
+import { type Session, useSession, useSessionFetch } from "@/lib/auth-client";
 import { link, ORPCContext, type orpc } from "@/utils/orpc";
 import type { appRouter } from "../../../server/src/routers";
 import "../index.css";
@@ -27,6 +27,8 @@ import "../index.css";
 export interface RouterAppContext {
   orpc: typeof orpc;
   queryClient: QueryClient;
+  auth: Session | null;
+  isAuthenticated: boolean;
 }
 
 export const Route = createRootRouteWithContext<RouterAppContext>()({

--- a/apps/web/src/routes/_auth/signin.tsx
+++ b/apps/web/src/routes/_auth/signin.tsx
@@ -15,7 +15,7 @@ export const Route = createFileRoute("/_auth/signin")({
   beforeLoad: async ({ context, search }) => {
     if (search.scope !== "token") {
       if (context.isAuthenticated) {
-        redirect({ to: "/" });
+        throw redirect({ to: "/" });
       }
     }
   },

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/")({
   beforeLoad: async ({ context }) => {
     const queryClient = context.queryClient;
     await queryClient.prefetchQuery(orpc.healthCheck.queryOptions());
-    if (context.auth?.isAuthenticated) {
+    if (context.isAuthenticated) {
       throw redirect({ to: "/dashboard" });
     }
   },

--- a/apps/web/src/routes/transactions.tsx
+++ b/apps/web/src/routes/transactions.tsx
@@ -71,7 +71,7 @@ export const Route = createFileRoute("/transactions")({
     context,
     search,
   }: {
-    context: RouterAppContext & { isAuthenticated: boolean };
+    context: RouterAppContext;
     search: SearchParams;
   }) => {
     ensureSession(context.isAuthenticated, "/transactions");


### PR DESCRIPTION
## Summary
- `/signin`'s signed-in guard called `redirect({ to: "/" })` without `throw`, so the router silently discarded it — signed-in users visiting `/signin` saw the sign-in form instead of being redirected. Verified against installed `@tanstack/router-core` (`redirect()` only throws with `{ throw: true }`)
- Removed the redundant `isAuthenticated: true` field embedded inside the session payload (trivially true whenever non-null)
- Declared `auth` / `isAuthenticated` once on `RouterAppContext`; dropped the local type widening in transactions route; `index.tsx` now reads `context.isAuthenticated` like every other route

## Validation
- `npm run check-types` passes across all workspaces
- Manual checks recommended: signed-in visit to `/signin` redirects to `/`; Discord OAuth callback (with `scope=token`) still lands on signin correctly