### PR TITLE
refactor(web): consolidate settings updates into one useUpdateSettings hook

### DIFF
--- a/apps/web/src/components/settings/developer-mode-toggle.tsx
+++ b/apps/web/src/components/settings/developer-mode-toggle.tsx
@@ -1,4 +1,3 @@
-import { useMutation } from "@tanstack/react-query";
 import { Code, Code2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -7,109 +6,28 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useUpdateSettings } from "@/hooks/use-update-settings";
 import { useSession } from "@/lib/auth-client";
-import { orpc, queryClient } from "@/utils/orpc";
 
 export function DeveloperModeToggle() {
   const { data: session } = useSession();
   const isDevMode = session?.settings?.isDevMode ?? false;
 
-  const { mutate: updateSettings, isPending } = useMutation(
-    orpc.settings.updateSettings.mutationOptions({
-      onMutate: async (newSettings) => {
-        await queryClient.cancelQueries({
-          queryKey: orpc.settings.getUserSettings.queryOptions().queryKey,
-        });
-
-        const previousSettings = queryClient.getQueryData(
-          orpc.settings.getUserSettings.queryOptions().queryKey,
-        );
-
-        queryClient.setQueryData(
-          orpc.settings.getUserSettings.queryOptions().queryKey,
-          (
-            old:
-              | { settings: { isDevMode: boolean; isPrivacyMode: boolean } }
-              | undefined,
-          ) => ({
-            ...old,
-            settings: newSettings,
-          }),
-        );
-
-        queryClient.setQueryData(
-          ["session"],
-          (
-            old:
-              | { settings: { isDevMode: boolean; isPrivacyMode: boolean } }
-              | undefined,
-          ) => ({
-            ...old,
-            settings: newSettings,
-          }),
-        );
-
-        return { previousSettings };
-      },
-      onError: (err, newSettings, context) => {
-        if (context?.previousSettings) {
-          queryClient.setQueryData(
-            orpc.settings.getUserSettings.queryOptions().queryKey,
-            context.previousSettings,
-          );
-        }
-
-        queryClient.setQueryData(
-          ["session"],
-          (
-            old:
-              | { settings: { isDevMode: boolean; isPrivacyMode: boolean } }
-              | undefined,
-          ) => ({
-            ...old,
-            settings: session?.settings,
-          }),
-        );
-
-        toast.error("Failed to update developer mode", {
-          description:
-            err instanceof Error
-              ? `Error: ${err.message}`
-              : "An unexpected error occurred. Please try again.",
-          duration: 5000,
-          action: {
-            label: "Retry",
-            onClick: () => {
-              updateSettings(newSettings);
-            },
-          },
-        });
-      },
-      onSuccess: (data) => {
-        queryClient.invalidateQueries({
-          queryKey: orpc.settings.getUserSettings.queryOptions().queryKey,
-        });
-        queryClient.invalidateQueries({
-          queryKey: ["session"],
-        });
-
-        const newDevMode = data.settings.isDevMode;
-        toast.success(`Developer mode ${newDevMode ? "enabled" : "disabled"}`, {
-          description: newDevMode
+  const { mutate: updateSettings, isPending } = useUpdateSettings({
+    errorTitle: "Failed to update developer mode",
+    showRetry: true,
+    onSuccess: (settings) => {
+      toast.success(
+        `Developer mode ${settings.isDevMode ? "enabled" : "disabled"}`,
+        {
+          description: settings.isDevMode
             ? "Developer tools are now visible"
             : "Developer tools are now hidden",
           duration: 3000,
-        });
-      },
-    }),
-  );
-
-  const handleDeveloperModeToggle = () => {
-    updateSettings({
-      isDevMode: !isDevMode,
-      isPrivacyMode: session?.settings?.isPrivacyMode ?? false,
-    });
-  };
+        },
+      );
+    },
+  });
 
   return (
     <Tooltip>
@@ -117,7 +35,7 @@ export function DeveloperModeToggle() {
         <Button
           variant="outline"
           size="icon"
-          onClick={handleDeveloperModeToggle}
+          onClick={() => updateSettings({ isDevMode: !isDevMode })}
           disabled={isPending}
         >
           {isDevMode ? (

--- a/apps/web/src/components/settings/privacy-mode-toggle.tsx
+++ b/apps/web/src/components/settings/privacy-mode-toggle.tsx
@@ -1,4 +1,3 @@
-import { useMutation } from "@tanstack/react-query";
 import { Eye, EyeOff } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -7,119 +6,28 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useUpdateSettings } from "@/hooks/use-update-settings";
 import { useSession } from "@/lib/auth-client";
-import { orpc, queryClient } from "@/utils/orpc";
 
 export function PrivacyModeToggle() {
   const { data: session } = useSession();
   const isPrivacyMode = session?.settings?.isPrivacyMode ?? false;
 
-  const { mutate: updateSettings, isPending } = useMutation(
-    orpc.settings.updateSettings.mutationOptions({
-      onMutate: async (newSettings) => {
-        // Cancel any outgoing refetches
-        await queryClient.cancelQueries({
-          queryKey: orpc.settings.getUserSettings.queryOptions().queryKey,
-        });
-
-        // Snapshot the previous value
-        const previousSettings = queryClient.getQueryData(
-          orpc.settings.getUserSettings.queryOptions().queryKey,
-        );
-
-        // Optimistically update to the new value
-        queryClient.setQueryData(
-          orpc.settings.getUserSettings.queryOptions().queryKey,
-          (
-            old:
-              | { settings: { isDevMode: boolean; isPrivacyMode: boolean } }
-              | undefined,
-          ) => ({
-            ...old,
-            settings: newSettings,
-          }),
-        );
-
-        // Also update session data optimistically
-        queryClient.setQueryData(
-          ["session"],
-          (
-            old:
-              | { settings: { isDevMode: boolean; isPrivacyMode: boolean } }
-              | undefined,
-          ) => ({
-            ...old,
-            settings: newSettings,
-          }),
-        );
-
-        // Return a context object with the snapshotted value
-        return { previousSettings };
-      },
-      onError: (err, newSettings, context) => {
-        // If the mutation fails, use the context returned from onMutate to roll back
-        if (context?.previousSettings) {
-          queryClient.setQueryData(
-            orpc.settings.getUserSettings.queryOptions().queryKey,
-            context.previousSettings,
-          );
-        }
-
-        // Also revert session data
-        queryClient.setQueryData(
-          ["session"],
-          (
-            old:
-              | { settings: { isDevMode: boolean; isPrivacyMode: boolean } }
-              | undefined,
-          ) => ({
-            ...old,
-            settings: session?.settings,
-          }),
-        );
-
-        toast.error("Failed to update privacy mode", {
-          description:
-            err instanceof Error
-              ? `Error: ${err.message}`
-              : "An unexpected error occurred. Please try again.",
-          duration: 5000,
-          action: {
-            label: "Retry",
-            onClick: () => {
-              updateSettings(newSettings);
-            },
-          },
-        });
-      },
-      onSuccess: (data) => {
-        queryClient.invalidateQueries({
-          queryKey: orpc.settings.getUserSettings.queryOptions().queryKey,
-        });
-        queryClient.invalidateQueries({
-          queryKey: ["session"],
-        });
-
-        const newPrivacyMode = data.settings.isPrivacyMode;
-        toast.success(
-          `Privacy mode ${newPrivacyMode ? "enabled" : "disabled"}`,
-          {
-            description: newPrivacyMode
-              ? "Sensitive information is now hidden"
-              : "Sensitive information is now visible",
-            duration: 3000,
-          },
-        );
-      },
-    }),
-  );
-
-  const handlePrivacyModeToggle = () => {
-    updateSettings({
-      isPrivacyMode: !isPrivacyMode,
-      isDevMode: session?.settings?.isDevMode ?? false,
-    });
-  };
+  const { mutate: updateSettings, isPending } = useUpdateSettings({
+    errorTitle: "Failed to update privacy mode",
+    showRetry: true,
+    onSuccess: (settings) => {
+      toast.success(
+        `Privacy mode ${settings.isPrivacyMode ? "enabled" : "disabled"}`,
+        {
+          description: settings.isPrivacyMode
+            ? "Sensitive information is now hidden"
+            : "Sensitive information is now visible",
+          duration: 3000,
+        },
+      );
+    },
+  });
 
   return (
     <Tooltip>
@@ -127,7 +35,7 @@ export function PrivacyModeToggle() {
         <Button
           variant="outline"
           size="icon"
-          onClick={handlePrivacyModeToggle}
+          onClick={() => updateSettings({ isPrivacyMode: !isPrivacyMode })}
           disabled={isPending}
         >
           {isPrivacyMode ? (

--- a/apps/web/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/web/src/hooks/use-keyboard-shortcuts.ts
@@ -1,54 +1,44 @@
 import { useHotkey } from "@tanstack/react-hotkeys";
-import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { useUpdateSettings } from "@/hooks/use-update-settings";
 import { useSession } from "@/lib/auth-client";
-import { orpc, queryClient } from "@/utils/orpc";
 
 export function useKeyboardShortcuts() {
   const { data: session } = useSession();
 
-  const { mutate: updateSettings } = useMutation(
-    orpc.settings.updateSettings.mutationOptions({
-      onSuccess: () => {
-        queryClient.invalidateQueries({
-          queryKey: orpc.settings.getUserSettings.queryOptions().queryKey,
-        });
-        queryClient.invalidateQueries({
-          queryKey: ["session"],
-        });
-      },
-      onError: (err) => {
-        toast.error("Failed to update settings", {
-          description:
-            err instanceof Error
-              ? `Error: ${err.message}`
-              : "An unexpected error occurred. Please try again.",
-          duration: 5000,
-        });
-      },
-    }),
-  );
-
-  useHotkey(
-    "Mod+Shift+D",
-    () => {
-      if (!session?.settings) return;
-
-      const currentDevMode = session.settings.isDevMode ?? false;
-      updateSettings({
-        isDevMode: !currentDevMode,
-        isPrivacyMode: session.settings.isPrivacyMode ?? false,
-      });
-
+  const { mutate: toggleDevMode } = useUpdateSettings({
+    onSuccess: (settings) => {
       toast.success(
-        `Developer mode ${!currentDevMode ? "enabled" : "disabled"}`,
+        `Developer mode ${settings.isDevMode ? "enabled" : "disabled"}`,
         {
-          description: !currentDevMode
+          description: settings.isDevMode
             ? "Developer tools are now visible"
             : "Developer tools are now hidden",
           duration: 3000,
         },
       );
+    },
+  });
+
+  const { mutate: togglePrivacyMode } = useUpdateSettings({
+    onSuccess: (settings) => {
+      toast.success(
+        `Privacy mode ${settings.isPrivacyMode ? "enabled" : "disabled"}`,
+        {
+          description: settings.isPrivacyMode
+            ? "Sensitive information is now hidden"
+            : "Sensitive information is now visible",
+          duration: 3000,
+        },
+      );
+    },
+  });
+
+  useHotkey(
+    "Mod+Shift+D",
+    () => {
+      if (!session?.settings) return;
+      toggleDevMode({ isDevMode: !(session.settings.isDevMode ?? false) });
     },
     { enabled: !!session?.settings },
   );
@@ -57,22 +47,9 @@ export function useKeyboardShortcuts() {
     "Mod+Shift+P",
     () => {
       if (!session?.settings) return;
-
-      const currentPrivacyMode = session.settings.isPrivacyMode ?? false;
-      updateSettings({
-        isDevMode: session.settings.isDevMode ?? false,
-        isPrivacyMode: !currentPrivacyMode,
+      togglePrivacyMode({
+        isPrivacyMode: !(session.settings.isPrivacyMode ?? false),
       });
-
-      toast.success(
-        `Privacy mode ${!currentPrivacyMode ? "enabled" : "disabled"}`,
-        {
-          description: !currentPrivacyMode
-            ? "Sensitive information is now hidden"
-            : "Sensitive information is now visible",
-          duration: 3000,
-        },
-      );
     },
     { enabled: !!session?.settings },
   );

--- a/apps/web/src/hooks/use-update-settings.ts
+++ b/apps/web/src/hooks/use-update-settings.ts
@@ -1,0 +1,111 @@
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { orpc, queryClient } from "@/utils/orpc";
+
+export interface UserSettings {
+  isDevMode: boolean;
+  isPrivacyMode: boolean;
+  webhookUrls?: string[];
+}
+
+export type UpdateSettingsPatch = Partial<UserSettings>;
+
+const SETTINGS_QUERY_KEY =
+  orpc.settings.getUserSettings.queryOptions().queryKey;
+const SESSION_QUERY_KEY = ["session"];
+
+function getCachedSettings(): UserSettings {
+  const fromSettings = queryClient.getQueryData<{
+    settings: UserSettings;
+  }>(SETTINGS_QUERY_KEY)?.settings;
+  if (fromSettings) return fromSettings;
+
+  const fromSession = queryClient.getQueryData<{
+    settings?: UserSettings;
+  }>(SESSION_QUERY_KEY)?.settings;
+  return fromSession ?? { isDevMode: false, isPrivacyMode: false };
+}
+
+/**
+ * Single owner of the settings-update flow: merges a partial patch over the
+ * currently cached settings (preserving fields the caller didn't specify),
+ * optimistically writes both the settings and session caches from one
+ * snapshot, restores both from that snapshot on error, and invalidates both
+ * on success.
+ */
+export function useUpdateSettings(options?: {
+  errorTitle?: string;
+  showRetry?: boolean;
+  onSuccess?: (settings: {
+    isDevMode: boolean;
+    isPrivacyMode: boolean;
+    webhookUrls?: string[] | null;
+  }) => void;
+}) {
+  const mutation = useMutation(
+    orpc.settings.updateSettings.mutationOptions({
+      onMutate: async (newSettings: UserSettings) => {
+        await queryClient.cancelQueries({ queryKey: SETTINGS_QUERY_KEY });
+
+        const previousSettings = queryClient.getQueryData(SETTINGS_QUERY_KEY);
+        const previousSession = queryClient.getQueryData(SESSION_QUERY_KEY);
+
+        queryClient.setQueryData(
+          SETTINGS_QUERY_KEY,
+          (old: { settings?: UserSettings } | undefined) => ({
+            ...old,
+            settings: newSettings,
+          }),
+        );
+        queryClient.setQueryData(
+          SESSION_QUERY_KEY,
+          (old: { settings?: UserSettings } | undefined) => ({
+            ...old,
+            settings: newSettings,
+          }),
+        );
+
+        return { previousSettings, previousSession };
+      },
+      onError: (err, newSettings, context) => {
+        if (context?.previousSettings !== undefined) {
+          queryClient.setQueryData(
+            SETTINGS_QUERY_KEY,
+            context.previousSettings,
+          );
+        }
+        if (context?.previousSession !== undefined) {
+          queryClient.setQueryData(SESSION_QUERY_KEY, context.previousSession);
+        }
+
+        toast.error(options?.errorTitle ?? "Failed to update settings", {
+          description:
+            err instanceof Error
+              ? `Error: ${err.message}`
+              : "An unexpected error occurred. Please try again.",
+          duration: 5000,
+          ...(options?.showRetry && {
+            action: {
+              label: "Retry",
+              onClick: () => {
+                mutation.mutate(newSettings);
+              },
+            },
+          }),
+        });
+      },
+      onSuccess: (data) => {
+        queryClient.invalidateQueries({ queryKey: SETTINGS_QUERY_KEY });
+        queryClient.invalidateQueries({ queryKey: SESSION_QUERY_KEY });
+
+        options?.onSuccess?.(data.settings);
+      },
+    }),
+  );
+
+  return {
+    ...mutation,
+    mutate: (patch: UpdateSettingsPatch) =>
+      mutation.mutate({ ...getCachedSettings(), ...patch }),
+  };
+}

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -13,8 +13,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Section } from "@/components/ui/section";
 import { Switch } from "@/components/ui/switch";
+import { useUpdateSettings } from "@/hooks/use-update-settings";
 import { ensureSession, useSession } from "@/lib/auth-client";
-import { orpc, queryClient } from "@/utils/orpc";
+import { orpc } from "@/utils/orpc";
 
 export const Route = createFileRoute("/settings")({
   component: RouteComponent,
@@ -44,134 +45,38 @@ function RouteComponent() {
 
   const webhookUrls: string[] = settingsData?.settings?.webhookUrls ?? [];
 
-  const { mutate: updateSettings, isPending } = useMutation(
-    orpc.settings.updateSettings.mutationOptions({
-      onMutate: async (newSettings) => {
-        await queryClient.cancelQueries({
-          queryKey: orpc.settings.getUserSettings.queryOptions().queryKey,
-        });
+  const { mutate: updateSettings, isPending } = useUpdateSettings({
+    showRetry: true,
+    onSuccess: (newSettings) => {
+      const changedSettings = [];
+      const oldSettings = session?.settings;
 
-        const previousSettings = queryClient.getQueryData(
-          orpc.settings.getUserSettings.queryOptions().queryKey,
+      if (newSettings.isDevMode !== oldSettings?.isDevMode) {
+        changedSettings.push({
+          name: "Developer mode",
+          enabled: newSettings.isDevMode,
+        });
+      }
+      if (newSettings.isPrivacyMode !== oldSettings?.isPrivacyMode) {
+        changedSettings.push({
+          name: "Privacy mode",
+          enabled: newSettings.isPrivacyMode,
+        });
+      }
+
+      if (changedSettings.length > 0) {
+        const descriptions = changedSettings.map(
+          (setting) =>
+            `${setting.name} has been ${setting.enabled ? "enabled" : "disabled"}`,
         );
 
-        queryClient.setQueryData(
-          orpc.settings.getUserSettings.queryOptions().queryKey,
-          (
-            old:
-              | {
-                  settings: {
-                    isDevMode: boolean;
-                    isPrivacyMode: boolean;
-                    webhookUrls?: string[];
-                  };
-                }
-              | undefined,
-          ) => ({
-            ...old,
-            settings: newSettings,
-          }),
-        );
-
-        queryClient.setQueryData(
-          ["session"],
-          (
-            old:
-              | {
-                  settings: {
-                    isDevMode: boolean;
-                    isPrivacyMode: boolean;
-                    webhookUrls?: string[];
-                  };
-                }
-              | undefined,
-          ) => ({
-            ...old,
-            settings: newSettings,
-          }),
-        );
-
-        return { previousSettings };
-      },
-      onError: (err, newSettings, context) => {
-        if (context?.previousSettings) {
-          queryClient.setQueryData(
-            orpc.settings.getUserSettings.queryOptions().queryKey,
-            context.previousSettings,
-          );
-        }
-
-        queryClient.setQueryData(
-          ["session"],
-          (
-            old:
-              | {
-                  settings: {
-                    isDevMode: boolean;
-                    isPrivacyMode: boolean;
-                    webhookUrls?: string[];
-                  };
-                }
-              | undefined,
-          ) => ({
-            ...old,
-            settings: session?.settings,
-          }),
-        );
-
-        toast.error("Failed to update settings", {
-          description:
-            err instanceof Error
-              ? `Error: ${err.message}`
-              : "An unexpected error occurred. Please try again.",
-          duration: 5000,
-          action: {
-            label: "Retry",
-            onClick: () => {
-              updateSettings(newSettings);
-            },
-          },
+        toast.success("Settings updated", {
+          description: descriptions.join(". "),
+          duration: 4000,
         });
-      },
-      onSuccess: (data) => {
-        queryClient.invalidateQueries({
-          queryKey: orpc.settings.getUserSettings.queryOptions().queryKey,
-        });
-        queryClient.invalidateQueries({
-          queryKey: ["session"],
-        });
-
-        const changedSettings = [];
-        const oldSettings = session?.settings;
-        const newSettings = data.settings;
-
-        if (newSettings.isDevMode !== oldSettings?.isDevMode) {
-          changedSettings.push({
-            name: "Developer mode",
-            enabled: newSettings.isDevMode,
-          });
-        }
-        if (newSettings.isPrivacyMode !== oldSettings?.isPrivacyMode) {
-          changedSettings.push({
-            name: "Privacy mode",
-            enabled: newSettings.isPrivacyMode,
-          });
-        }
-
-        if (changedSettings.length > 0) {
-          const descriptions = changedSettings.map(
-            (setting) =>
-              `${setting.name} has been ${setting.enabled ? "enabled" : "disabled"}`,
-          );
-
-          toast.success("Settings updated", {
-            description: descriptions.join(". "),
-            duration: 4000,
-          });
-        }
-      },
-    }),
-  );
+      }
+    },
+  });
 
   const [isConfirmPasswordOpen, setIsConfirmPasswordOpen] = useState(false);
 
@@ -302,12 +207,7 @@ function RouteComponent() {
                               return;
                             }
                             const updatedUrls = [...webhookUrls, url];
-                            updateSettings({
-                              isDevMode: session?.settings?.isDevMode ?? false,
-                              isPrivacyMode:
-                                session?.settings?.isPrivacyMode ?? false,
-                              webhookUrls: updatedUrls,
-                            });
+                            updateSettings({ webhookUrls: updatedUrls });
                             setNewWebhookUrl("");
                             toast.success("Webhook URL added");
                           } catch {
@@ -329,12 +229,7 @@ function RouteComponent() {
                           return;
                         }
                         const updatedUrls = [...webhookUrls, url];
-                        updateSettings({
-                          isDevMode: session?.settings?.isDevMode ?? false,
-                          isPrivacyMode:
-                            session?.settings?.isPrivacyMode ?? false,
-                          webhookUrls: updatedUrls,
-                        });
+                        updateSettings({ webhookUrls: updatedUrls });
                         setNewWebhookUrl("");
                         toast.success("Webhook URL added");
                       } catch {
@@ -363,12 +258,7 @@ function RouteComponent() {
                           const updatedUrls = webhookUrls.filter(
                             (u: string) => u !== url,
                           );
-                          updateSettings({
-                            isDevMode: session?.settings?.isDevMode ?? false,
-                            isPrivacyMode:
-                              session?.settings?.isPrivacyMode ?? false,
-                            webhookUrls: updatedUrls,
-                          });
+                          updateSettings({ webhookUrls: updatedUrls });
                           toast.success("Webhook URL removed");
                         }}
                         size="sm"
@@ -413,8 +303,6 @@ function RouteComponent() {
                   onCheckedChange={() => {
                     updateSettings({
                       isDevMode: !(session?.settings?.isDevMode ?? false),
-                      isPrivacyMode: session?.settings?.isPrivacyMode ?? false,
-                      webhookUrls: webhookUrls,
                     });
                   }}
                 />
@@ -447,8 +335,6 @@ function RouteComponent() {
                       isPrivacyMode: !(
                         session?.settings?.isPrivacyMode ?? false
                       ),
-                      isDevMode: session?.settings?.isDevMode ?? false,
-                      webhookUrls: webhookUrls,
                     });
                   }}
                 />


### PR DESCRIPTION
## Summary
- Four copy-pasted optimistic `updateSettings` mutations (settings page, developer-mode toggle, privacy-mode toggle, keyboard shortcuts) each re-implemented the cancel → snapshot → dual-cache write → rollback → invalidate flow with divergent details
- The toggles and shortcuts sent payloads **without** `webhookUrls`, which optimistically erased the webhook list from both caches until the post-success refetch
- Rollback for the `session` cache restored from a stale render-scope closure instead of the mutation snapshot

New `useUpdateSettings` hook:
- Accepts a **partial patch**, merged over the currently cached settings before sending — callers can no longer accidentally drop fields
- Writes both caches from a single snapshot; restores **both** caches from that same snapshot on error
- Invalidates both caches on success; per-site success toasts preserved via an `onSuccess` callback
- Net −200 lines across the four call sites

## Behavior changes
- Keyboard shortcut toasts now fire on success (previously fired immediately, even if the request failed) and failures now surface an error toast
- Toggling dev/privacy mode from the topbar or shortcuts no longer blanks webhooks in the cache

## Validation
- `npm run check-types` passes across all workspaces; Biome clean
- Manual checks recommended: toggle dev/privacy from settings page, topbar buttons, and Mod+Shift+D/P with network throttled; add/remove a webhook then toggle dev mode and confirm webhooks survive